### PR TITLE
fix(rollup): add babel and react configs

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,6 +13,9 @@ const output = (name, format) => ({
     bufferutil: 'bufferutil',
     'utf-8-validate': 'utf8Validate',
     'spawn-sync': 'spawnSync',
+    react: 'React',
+    'react-dom': 'ReactDOM',
+    'prop-types': 'PropTypes',
   },
 });
 
@@ -28,7 +31,9 @@ export default [
       resolve({
         preferBuiltins: true,
       }),
-      babel(),
+      babel({
+        runtimeHelpers: true,
+      }),
       commonJS(),
       json(),
       builtins(),
@@ -40,7 +45,7 @@ export default [
       // Use default for everything else
       warn(warning);
     },
-    external: ['bufferutil', 'utf-8-validate', 'spawn-sync'],
+    external: ['bufferutil', 'utf-8-validate', 'spawn-sync', 'react', 'react-dom', 'prop-types'],
     context: 'null',
   },
 ];


### PR DESCRIPTION
runtimeHelpers were added to the base babel config in order to get the tests working with observables. 

Also added react rollup configs due to base adapters being part of the components repo.