### PR TITLE
@webex/common custom export - rollup

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -34,7 +34,11 @@ export default [
       babel({
         runtimeHelpers: true,
       }),
-      commonJS(),
+      commonJS({
+        // TODO: Remove workaround once fixed in SDK
+        // explicitly specify unresolvable named exports
+        namedExports: {'@webex/common': ['deconstructHydraId']},
+      }),
       json(),
       builtins(),
     ],


### PR DESCRIPTION
```js
Object.defineProperty(exports, 'deconstructHydraId', {
  enumerable: true,
  get: function get() {
    return _uuidUtils.deconstructHydraId;
  }
});
```
will force us to use `custom exports` for the methods to be appropriately exported. 

Also, I turned on the `Prod` env to build.