### PR TITLE
getMe() and getPerson() handle users with no presence

### DIFF
--- a/src/PeopleSDKAdapter.js
+++ b/src/PeopleSDKAdapter.js
@@ -65,10 +65,14 @@ export default class PeopleSDKAdapter extends PeopleAdapter {
    * @memberof PeopleSDKAdapter
    */
   getMe() {
+    // Get person data of the current access token bearer
     return defer(() => this.fetchPerson('me')).pipe(
       flatMap((person) =>
+        // Get person status information from presence plug-in
         defer(() => this.datasource.internal.presence.get([person.id])).pipe(
-          catchError(() => of({status: null})), // When SDK throws error, don't set a status
+          // When SDK throws error, don't set a status
+          catchError(() => of({status: null})),
+          // Combine person data and presence data to send back
           map(({status}) => ({...person, status: this.getStatus(status)}))
         )
       )

--- a/src/PeopleSDKAdapter.js
+++ b/src/PeopleSDKAdapter.js
@@ -20,7 +20,8 @@ export default class PeopleSDKAdapter extends PeopleAdapter {
   }
 
   /**
-   * Returns a proper Enum key for a given PersonStatus value
+   * Returns a PersonStatus enum key from the given value.
+   * If status does not match an enum key, it returns null.
    *
    * @private
    * @param {string} status  Person status from Apheleia service.
@@ -28,7 +29,9 @@ export default class PeopleSDKAdapter extends PeopleAdapter {
    * @memberof PeopleSDKAdapter
    */
   getStatus(status) {
-    return Object.keys(PersonStatus).find((key) => PersonStatus[key] === status);
+    const personStatus = Object.keys(PersonStatus).find((key) => PersonStatus[key] === status);
+
+    return personStatus === undefined ? null : personStatus;
   }
 
   /**

--- a/src/PeopleSDKAdapter.test.js
+++ b/src/PeopleSDKAdapter.test.js
@@ -80,26 +80,25 @@ describe('People SDK Adapter', () => {
       });
     });
 
+    test('emits a Person object with null status on presence plug-in error', (done) => {
+      const errorMessage = 'error while subscribing to presence updates';
+
+      // SDK presence plug-in fails to subscribe to person status updates
+      mockSDK.internal.presence.subscribe = jest.fn(() => Promise.reject(new Error(errorMessage)));
+
+      peopleSDKAdapter.getPerson(personID).subscribe((person) => {
+        expect(person).toMatchObject({
+          status: null,
+        });
+        done();
+      });
+    });
+
     test('throws error on people plug-in error', (done) => {
       const errorMessage = 'Could not find person with given ID';
 
       // SDK people plug-in fails to find person
       peopleSDKAdapter.fetchPerson = jest.fn(() => Promise.reject(new Error(errorMessage)));
-
-      peopleSDKAdapter.getPerson(personID).subscribe(
-        () => {},
-        (error) => {
-          expect(error.message).toBe(errorMessage);
-          done();
-        }
-      );
-    });
-
-    test('throws error on failed presence plug-in update subscription', (done) => {
-      const errorMessage = 'error while subscribing to presence updates';
-
-      // SDK presence plug-in fails to subscribe to person status updates
-      mockSDK.internal.presence.subscribe = jest.fn(() => Promise.reject(new Error(errorMessage)));
 
       peopleSDKAdapter.getPerson(personID).subscribe(
         () => {},

--- a/src/PeopleSDKAdapter.test.js
+++ b/src/PeopleSDKAdapter.test.js
@@ -28,6 +28,18 @@ describe('People SDK Adapter', () => {
         done();
       });
     });
+
+    test('emits a Person object with null status on presence plug-in error', (done) => {
+      // SDK presence plug-in fails to return a status
+      mockSDK.internal.presence.get = jest.fn(() => Promise.reject(new Error()));
+
+      peopleSDKAdapter.getMe().subscribe((person) => {
+        expect(person).toMatchObject({
+          status: null,
+        });
+        done();
+      });
+    });
   });
 
   describe('getPerson()', () => {

--- a/src/PeopleSDKAdapter.test.js
+++ b/src/PeopleSDKAdapter.test.js
@@ -13,7 +13,11 @@ describe('People SDK Adapter', () => {
   });
 
   describe('getMe()', () => {
-    test('returns a person in a proper shape', (done) => {
+    test('returns an observable', () => {
+      expect(isObservable(peopleSDKAdapter.getMe())).toBeTruthy();
+    });
+
+    test('emits a Person object on subscription', (done) => {
       peopleSDKAdapter.getMe().subscribe((person) => {
         expect(person).toMatchObject({
           ID: 'id',
@@ -39,6 +43,17 @@ describe('People SDK Adapter', () => {
         });
         done();
       });
+    });
+
+    test('completes after one emission', (done) => {
+      peopleSDKAdapter.getMe().subscribe(
+        () => {},
+        () => {},
+        () => {
+          expect(true).toBeTruthy();
+          done();
+        }
+      );
     });
   });
 


### PR DESCRIPTION
Whenever a user did not have presence enabled, the observables returned from `getMe()` and `getPerson()` would error out.
This PR handles users with a disabled presence (status in Teams).
In practice, this makes the observable error out in the components and also complete the observables when they were expected to be kept alive.