### PR TITLE
Fix Audio and Video Mute at Join

### DIFF
--- a/src/MeetingsSDKAdapter.js
+++ b/src/MeetingsSDKAdapter.js
@@ -323,7 +323,6 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
   async joinMeeting(ID) {
     try {
       const sdkMeeting = this.fetchMeeting(ID);
-      const {localVideo} = this.meetings[ID];
       const localStream = new MediaStream();
 
       const localAudio = this.meetings[ID].localAudio || this.meetings[ID].disabledLocalAudio;
@@ -331,11 +330,10 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
 
       audioTracks.forEach((track) => localStream.addTrack(track));
 
-      if (localVideo) {
-        const tracks = localVideo.getTracks();
+      const localVideo = this.meetings[ID].localVideo || this.meetings[ID].disabledLocalVideo;
+      const videoTracks = localVideo.getTracks();
 
-        tracks.forEach((track) => localStream.addTrack(track));
-      }
+      videoTracks.forEach((track) => localStream.addTrack(track));
 
       await sdkMeeting.join();
 
@@ -347,7 +345,7 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
         await sdkMeeting.muteAudio();
       }
 
-      if (localVideo === null) {
+      if (this.meetings[ID].localVideo === null) {
         await sdkMeeting.muteVideo();
       }
     } catch (error) {

--- a/src/MeetingsSDKAdapter.js
+++ b/src/MeetingsSDKAdapter.js
@@ -323,14 +323,13 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
   async joinMeeting(ID) {
     try {
       const sdkMeeting = this.fetchMeeting(ID);
-      const {localAudio, localVideo} = this.meetings[ID];
+      const {localVideo} = this.meetings[ID];
       const localStream = new MediaStream();
 
-      if (localAudio) {
-        const tracks = localAudio.getTracks();
+      const localAudio = this.meetings[ID].localAudio || this.meetings[ID].disabledLocalAudio;
+      const audioTracks = localAudio.getTracks();
 
-        tracks.forEach((track) => localStream.addTrack(track));
-      }
+      audioTracks.forEach((track) => localStream.addTrack(track));
 
       if (localVideo) {
         const tracks = localVideo.getTracks();
@@ -344,7 +343,7 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
       await sdkMeeting.addMedia({localStream, mediaSettings});
 
       // Mute either streams after join if user had muted them before joining
-      if (localAudio === null) {
+      if (this.meetings[ID].localAudio === null) {
         await sdkMeeting.muteAudio();
       }
 


### PR DESCRIPTION
Fixes an issue where user can not mute or unmute if they join a meeting when the set their audio to be muted before joining meeting
when joining a meeting localAudio can't be set to null until tracks have been added to the local stream for audio

Fixes #SPARK-[148175](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-148174)