### PR TITLE
fix(rollup): remove webex/common from external add as named export

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,7 +8,6 @@ const output = (name, format) => ({
   format,
   sourcemap: true,
   globals: {
-    '@webex/common': '@webex.common',
     rxjs: 'rxjs',
     'rxjs/operators': 'rxjs.operators',
     webex: 'webex',
@@ -20,12 +19,16 @@ export default [
     input: 'src/index.js',
     output: [output('ESMWebexSDKComponentAdapter', 'esm')],
     plugins: [
-      resolve(),
+      resolve({preferBuiltins: false}),
       babel({
         runtimeHelpers: true,
       }),
-      commonJS(),
+      commonJS({
+        namedExports: {
+          '@webex/common': ['deconstructHydraId'],
+        },
+      }),
     ],
-    external: ['@webex/common', 'rxjs', 'rxjs/operators', 'webex'],
+    external: ['rxjs', 'rxjs/operators', 'webex'],
   },
 ];


### PR DESCRIPTION
This PR is to fix [SPARK-106451](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-106451) where we do not include @webex/common as an external dependency as the current workaround.  The common JS plugin for rollup needs to have namedExports in order to find the code properly please see here
https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module
