### PR TITLE
fix(meetingsSDKAdapter):  check media stream exists before getting tracks when joining

### DIFF
--- a/src/MeetingsSDKAdapter.js
+++ b/src/MeetingsSDKAdapter.js
@@ -326,12 +326,12 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
       const localStream = new MediaStream();
 
       const localAudio = this.meetings[ID].localAudio || this.meetings[ID].disabledLocalAudio;
-      const audioTracks = localAudio.getTracks();
+      const audioTracks = localAudio && localAudio.getTracks();
 
       audioTracks.forEach((track) => localStream.addTrack(track));
 
       const localVideo = this.meetings[ID].localVideo || this.meetings[ID].disabledLocalVideo;
-      const videoTracks = localVideo.getTracks();
+      const videoTracks = localVideo && localVideo.getTracks();
 
       videoTracks.forEach((track) => localStream.addTrack(track));
 


### PR DESCRIPTION
It will fix error get due to localAudio and local Video null. 
**Description**
I got this error when testing calling locally in Cantina. It doesn't occur usually I guess. I was using Desktop with having no input connected and no camera device connected. It might be occur due to other reason also. As  I seen there was Cors policy error above it. 