### PR TITLE
Update component adapter interfaces to v1.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2496,9 +2496,9 @@
       }
     },
     "@webex/component-adapter-interfaces": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webex/component-adapter-interfaces/-/component-adapter-interfaces-1.9.0.tgz",
-      "integrity": "sha512-sTBHmLE8V9EdDxv9mflVS73cVLMBDvCkTQmTkXoNxwxJGpRO6G2YVeiHh/i07X3xNGelAfF+KCI2rr9DicfNvQ=="
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@webex/component-adapter-interfaces/-/component-adapter-interfaces-1.11.0.tgz",
+      "integrity": "sha512-XSlgvKudRatq1gmgD0EZ5PjHp0SGbvrfqqfHUCIEufZMl4wEcvOHPmWzZe3H9CQSkaLKUa7Jf8ngOa8KMOYBWA=="
     },
     "@webex/eslint-config-base": {
       "version": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "author": "devsupport@webex.com",
   "license": "MIT",
   "dependencies": {
-    "@webex/component-adapter-interfaces": "^1.9.0"
+    "@webex/component-adapter-interfaces": "^1.11.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.6.4",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,14 @@
       "@babel/plugin-transform-runtime"
     ],
     "presets": [
-      "@babel/preset-env"
+      [
+        "@babel/preset-env",
+        {
+          "targets": {
+            "esmodules": true
+          }
+        }
+      ]
     ]
   },
   "jest": {


### PR DESCRIPTION
Also adds a babel config to fix test running.

Further reading: https://stackoverflow.com/questions/51860043/javascript-es6-typeerror-class-constructor-client-cannot-be-invoked-without-ne