### PR TITLE
Server improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,5 +120,8 @@
       "pre-commit": "npm run test:eslint",
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
-  }
+  },
+  "browserslist": [
+    "last 2 Chrome versions"
+  ]
 }

--- a/scripts/index.html
+++ b/scripts/index.html
@@ -9,6 +9,7 @@
         <form id="connector">
           <fieldset>
             <legend>JS SDK Connection</legend>
+            <input id="credentials" placeholder="Access Token" type="password" />
             <button id="connect">Connect</button>
             <button id="disconnect">Disconnect</button>
             <span id="connection-status"> Disconnected ❌ </span>
@@ -29,6 +30,13 @@
             <button id="mute-audio">Mute Audio</button>
             <button id="mute-video">Mute Video</button>
             <button id="share-screen">Screen Share</button>
+          </fieldset>
+        </form>
+        <form id="members">
+          <fieldset>
+            <legend>Members</legend>
+            <button id="get-members">Get Members</button>
+            <textarea id="members-list"></textarea>
           </fieldset>
         </form>
         <div style="display: flex; justify-content: space-between;">


### PR DESCRIPTION
This adds features to the `npm run serve` functionality that allows the user to input an access token instead of pulling from the .env file (thus making it more useful for automation tests in the future). Also adds membership support but is blocked by #77. 

The browserslist addition to `package.json` is required to be able to run `npm run serve` with the latest `webex` package. I've run a `npm run build` and `npm link` for the package to verify the browserslist addition didn't break anything and it works as expected when used in the widget repo.