### PR TITLE
refactor(MembershipsSdkAdapter): emit member lists from getMembersFromDestination

### DIFF
--- a/src/MembershipsSDKAdapter.test.js
+++ b/src/MembershipsSDKAdapter.test.js
@@ -21,31 +21,24 @@ describe('Memberships SDK Adapter', () => {
     });
 
     describe('when destination type is MEETING', () => {
-      test('emits a membership object on subscription', (done) => {
+      test('emits a member list on subscription', (done) => {
         membershipSDKAdapter.getMembersFromDestination(meetingID, DestinationType.MEETING)
-          .subscribe((membership) => {
-            expect(membership).toMatchObject({
-              ID: 'meeting-meetingID',
-              destinationID: meetingID,
-              destinationType: DestinationType.MEETING,
-              members: [
-                {
-                  id: 'id',
-                  inMeeting: true,
-                  muted: false,
-                },
-                {
-                  id: 'mutedPerson',
-                  inMeeting: true,
-                  muted: true,
-                },
-                {
-                  id: 'notJoinedPerson',
-                  inMeeting: false,
-                  muted: false,
-                },
-              ],
-            });
+          .subscribe((members) => {
+            expect(members).toMatchObject([
+              {
+                id: 'id',
+                muted: false,
+              },
+              {
+                id: 'mutedPerson',
+                muted: true,
+              },
+              {
+                id: 'notJoinedPerson',
+                inMeeting: false,
+                muted: false,
+              },
+            ]);
             done();
           });
       });


### PR DESCRIPTION
getmembersFromDestination should return an observable that emits member lists (instead of membership objects).

Contains changes from PR https://github.com/webex/sdk-component-adapter/pull/91, which should be merged first.