### PR TITLE
feat(MembershipsSdkAdapter): add orgID field to meeting members

### DIFF
--- a/src/MembershipsSDKAdapter.js
+++ b/src/MembershipsSDKAdapter.js
@@ -21,6 +21,7 @@ function getMembers(members) {
     .filter((member) => member.isUser)
     .map((member) => ({
       id: member.id,
+      orgID: member.participant && member.participant.person && member.participant.person.orgId,
       inMeeting: member.isInMeeting,
       muted: member.isAudioMuted,
       sharing: member.isContentSharing,

--- a/src/MembershipsSDKAdapter.test.js
+++ b/src/MembershipsSDKAdapter.test.js
@@ -27,18 +27,24 @@ describe('Memberships SDK Adapter', () => {
             expect(members).toMatchObject([
               {
                 id: 'id',
+                orgID: 'orgID',
+                inMeeting: true,
                 muted: false,
                 sharing: false,
               },
               {
                 id: 'mutedPerson',
+                orgID: 'orgID',
+                inMeeting: true,
                 muted: true,
                 sharing: true,
               },
               {
                 id: 'notJoinedPerson',
+                orgID: 'orgID',
                 inMeeting: false,
                 muted: false,
+                sharing: false,
               },
             ]);
             done();

--- a/src/mockSdk.js
+++ b/src/mockSdk.js
@@ -21,19 +21,28 @@ export const mockSDKMeeting = {
     membersCollection: {
       members: {
         person1: {
-          ...mockSDKPerson,
+          id: 'id',
           isInMeeting: true,
           isUser: true,
           isAudioMuted: false,
           isContentSharing: false,
+          participant: {
+            person: {
+              ...mockSDKPerson,
+            },
+          },
         },
         person2: {
-          ...mockSDKPerson,
           id: 'mutedPerson',
           isInMeeting: true,
           isUser: true,
           isAudioMuted: true,
           isContentSharing: true,
+          participant: {
+            person: {
+              ...mockSDKPerson,
+            },
+          },
         },
         notJoinedPerson: {
           ...mockSDKPerson,
@@ -42,6 +51,11 @@ export const mockSDKMeeting = {
           isUser: true,
           isAudioMuted: false,
           isContentSharing: false,
+          participant: {
+            person: {
+              ...mockSDKPerson,
+            },
+          },
         },
         device: {
           ...mockSDKPerson,
@@ -50,6 +64,11 @@ export const mockSDKMeeting = {
           isUser: false,
           isAudioMuted: false,
           isContentSharing: false,
+          participant: {
+            person: {
+              ...mockSDKPerson,
+            },
+          },
         },
       },
     },


### PR DESCRIPTION
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-220419

I changed mockSdk to match with real data from webex.

The real data:
![image](https://user-images.githubusercontent.com/8277264/113412712-aae46c80-93c1-11eb-85b6-2cc707203d0c.png)

The previous mock data
![image](https://user-images.githubusercontent.com/8277264/113412887-13334e00-93c2-11eb-8386-e3ddf7c0867c.png)

