### PR TITLE
fix(MeetingsSdkAdapter): update screen sharing icon

### DIFF
--- a/src/MeetingsSDKAdapter.js
+++ b/src/MeetingsSDKAdapter.js
@@ -750,21 +750,21 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
     const sdkMeeting = this.fetchMeeting(ID);
     const inactiveShare = {
       ID: SHARE_CONTROL,
-      icon: 'share',
+      icon: 'share-screen-presence-stroke',
       tooltip: 'Start Share',
       state: MeetingControlState.INACTIVE,
       text: null,
     };
     const activeShare = {
       ID: SHARE_CONTROL,
-      icon: 'share',
+      icon: 'share-screen-presence-stroke',
       tooltip: 'Stop Share',
       state: MeetingControlState.ACTIVE,
       text: null,
     };
     const disabledShare = {
       ID: SHARE_CONTROL,
-      icon: 'share',
+      icon: 'share-screen-presence-stroke',
       tooltip: 'Sharing is Unavailable',
       state: MeetingControlState.DISABLED,
       text: null,

--- a/src/MeetingsSDKAdapter.test.js
+++ b/src/MeetingsSDKAdapter.test.js
@@ -645,7 +645,7 @@ describe('Meetings SDK Adapter', () => {
       meetingSDKAdapter.shareControl(meetingID).subscribe((dataDisplay) => {
         expect(dataDisplay).toMatchObject({
           ID: 'share-screen',
-          icon: 'share',
+          icon: 'share-screen-presence-stroke',
           text: null,
         });
         done();


### PR DESCRIPTION
Update the MeetingsSdkAdapter to use the correct sharing icon. (share-screen-presence-stroke)
Link bug in Jira: https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-223771
subtask for this repo: https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-224249