### PR TITLE
fix(MeetingsSdkAdapter): update classes for icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.30.1](https://github.com/webex/sdk-component-adapter/compare/v1.30.0...v1.30.1) (2021-04-09)
+
+
+### Bug Fixes
+
+* **MeetingsSdkAdapter:** update screen sharing icon ([3b8da37](https://github.com/webex/sdk-component-adapter/commit/3b8da3792f25a37c3cc9587604516a944e880fe5))
+
 # [1.30.0](https://github.com/webex/sdk-component-adapter/compare/v1.29.0...v1.30.0) (2021-04-07)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/sdk-component-adapter",
-  "version": "1.30.0",
+  "version": "1.30.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/sdk-component-adapter",
-  "version": "1.30.0",
+  "version": "1.30.1",
   "main": "dist/webexSDKComponentAdapter.esm.js",
   "module": "dist/webexSDKComponentAdapter.esm.js",
   "scripts": {

--- a/src/MeetingsSDKAdapter.js
+++ b/src/MeetingsSDKAdapter.js
@@ -750,21 +750,21 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
     const sdkMeeting = this.fetchMeeting(ID);
     const inactiveShare = {
       ID: SHARE_CONTROL,
-      icon: 'share',
+      icon: 'share-screen-presence-stroke',
       tooltip: 'Start Share',
       state: MeetingControlState.INACTIVE,
       text: null,
     };
     const activeShare = {
       ID: SHARE_CONTROL,
-      icon: 'share',
+      icon: 'share-screen-presence-stroke',
       tooltip: 'Stop Share',
       state: MeetingControlState.ACTIVE,
       text: null,
     };
     const disabledShare = {
       ID: SHARE_CONTROL,
-      icon: 'share',
+      icon: 'share-screen-presence-stroke',
       tooltip: 'Sharing is Unavailable',
       state: MeetingControlState.DISABLED,
       text: null,

--- a/src/MeetingsSDKAdapter.js
+++ b/src/MeetingsSDKAdapter.js
@@ -470,7 +470,7 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
     return Observable.create((observer) => {
       observer.next({
         ID: EXIT_CONTROL,
-        icon: 'cancel',
+        icon: 'cancel_28',
         tooltip: 'Leave',
         state: MeetingControlState.ACTIVE,
       });
@@ -538,14 +538,14 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
     const sdkMeeting = this.fetchMeeting(ID);
     const muted = {
       ID: AUDIO_CONTROL,
-      icon: 'microphone-muted',
+      icon: 'microphone-muted_28',
       tooltip: 'Unmute',
       state: MeetingControlState.ACTIVE,
       text: null,
     };
     const unmuted = {
       ID: AUDIO_CONTROL,
-      icon: 'microphone-muted',
+      icon: 'microphone-muted_28',
       tooltip: 'Mute',
       state: MeetingControlState.INACTIVE,
       text: null,
@@ -628,14 +628,14 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
     const sdkMeeting = this.fetchMeeting(ID);
     const muted = {
       ID: VIDEO_CONTROL,
-      icon: 'camera-muted',
+      icon: 'camera-muted_28',
       tooltip: 'Start video',
       state: MeetingControlState.ACTIVE,
       text: null,
     };
     const unmuted = {
       ID: VIDEO_CONTROL,
-      icon: 'camera-muted',
+      icon: 'camera-muted_28',
       tooltip: 'Stop video',
       state: MeetingControlState.INACTIVE,
       text: null,
@@ -750,21 +750,21 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
     const sdkMeeting = this.fetchMeeting(ID);
     const inactiveShare = {
       ID: SHARE_CONTROL,
-      icon: 'share-screen-presence-stroke',
+      icon: 'share-screen-presence-stroke_26',
       tooltip: 'Start Share',
       state: MeetingControlState.INACTIVE,
       text: null,
     };
     const activeShare = {
       ID: SHARE_CONTROL,
-      icon: 'share-screen-presence-stroke',
+      icon: 'share-screen-presence-stroke_26',
       tooltip: 'Stop Share',
       state: MeetingControlState.ACTIVE,
       text: null,
     };
     const disabledShare = {
       ID: SHARE_CONTROL,
-      icon: 'share-screen-presence-stroke',
+      icon: 'share-screen-presence-stroke_26',
       tooltip: 'Sharing is Unavailable',
       state: MeetingControlState.DISABLED,
       text: null,
@@ -860,14 +860,14 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
     const sdkMeeting = this.fetchMeeting(ID);
     const active = {
       ID: ROSTER_CONTROL,
-      icon: 'participant-list',
+      icon: 'participant-list_28',
       tooltip: 'Hide participants panel',
       state: MeetingControlState.ACTIVE,
       text: 'Participants',
     };
     const inactive = {
       ID: ROSTER_CONTROL,
-      icon: 'participant-list',
+      icon: 'participant-list_28',
       tooltip: 'Show participants panel',
       state: MeetingControlState.INACTIVE,
       text: 'Participants',

--- a/src/MeetingsSDKAdapter.test.js
+++ b/src/MeetingsSDKAdapter.test.js
@@ -645,7 +645,7 @@ describe('Meetings SDK Adapter', () => {
       meetingSDKAdapter.shareControl(meetingID).subscribe((dataDisplay) => {
         expect(dataDisplay).toMatchObject({
           ID: 'share-screen',
-          icon: 'share',
+          icon: 'share-screen-presence-stroke',
           text: null,
         });
         done();

--- a/src/MeetingsSDKAdapter.test.js
+++ b/src/MeetingsSDKAdapter.test.js
@@ -413,7 +413,7 @@ describe('Meetings SDK Adapter', () => {
       meetingSDKAdapter.exitControl().subscribe((dataDisplay) => {
         expect(dataDisplay).toMatchObject({
           ID: 'leave-meeting',
-          icon: 'cancel',
+          icon: 'cancel_28',
           tooltip: 'Leave',
           state: 'active',
         });
@@ -427,7 +427,7 @@ describe('Meetings SDK Adapter', () => {
       meetingSDKAdapter.audioControl(meetingID).subscribe((dataDisplay) => {
         expect(dataDisplay).toMatchObject({
           ID: 'mute-audio',
-          icon: 'microphone-muted',
+          icon: 'microphone-muted_28',
           tooltip: 'Mute',
           state: 'inactive',
           text: null,
@@ -535,7 +535,7 @@ describe('Meetings SDK Adapter', () => {
       meetingSDKAdapter.videoControl(meetingID).subscribe((dataDisplay) => {
         expect(dataDisplay).toMatchObject({
           ID: 'mute-video',
-          icon: 'camera-muted',
+          icon: 'camera-muted_28',
           tooltip: 'Stop video',
           state: 'inactive',
           text: null,
@@ -645,7 +645,7 @@ describe('Meetings SDK Adapter', () => {
       meetingSDKAdapter.shareControl(meetingID).subscribe((dataDisplay) => {
         expect(dataDisplay).toMatchObject({
           ID: 'share-screen',
-          icon: 'share-screen-presence-stroke',
+          icon: 'share-screen-presence-stroke_26',
           text: null,
         });
         done();
@@ -738,7 +738,7 @@ describe('Meetings SDK Adapter', () => {
         try {
           expect(dataDisplay).toMatchObject({
             ID: 'member-roster',
-            icon: 'participant-list',
+            icon: 'participant-list_28',
             tooltip: 'Show participants panel',
             state: 'inactive',
             text: 'Participants',


### PR DESCRIPTION
Update the MeetingsSdkAdapter to use the correct classes of icons. (microphone-muted_28,camera-muted_28,cancel_28,share-screen-presence-stroke_26,microphone_28)
Link bug in Jira: https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-223771
subtask for this repo: https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-224249