### PR TITLE
fix(MeetingsSdkAdapter): prevent JavaScript errors when access to camera/microphone is denied

### DIFF
--- a/src/MeetingsSDKAdapter.js
+++ b/src/MeetingsSDKAdapter.js
@@ -390,14 +390,15 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
       const localStream = new MediaStream();
 
       const localAudio = this.meetings[ID].localAudio || this.meetings[ID].disabledLocalAudio;
-      const audioTracks = localAudio && localAudio.getTracks();
-
-      audioTracks.forEach((track) => localStream.addTrack(track));
-
       const localVideo = this.meetings[ID].localVideo || this.meetings[ID].disabledLocalVideo;
-      const videoTracks = localVideo && localVideo.getTracks();
 
-      videoTracks.forEach((track) => localStream.addTrack(track));
+      if (localAudio) {
+        localAudio.getTracks().forEach((track) => localStream.addTrack(track));
+      }
+
+      if (localVideo) {
+        localVideo.getTracks().forEach((track) => localStream.addTrack(track));
+      }
 
       await sdkMeeting.join();
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import './polyfills';
 import WebexSDKAdapter from './WebexSDKAdapter';
 
 export default WebexSDKAdapter;

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -1,0 +1,5 @@
+// dummy implementation of getTracks() for non-supporting browsers,
+// to avoid checking for its existence before calling it
+if (!MediaStream.prototype.getTracks) {
+  MediaStream.prototype.getTracks = () => [];
+}


### PR DESCRIPTION
When a user disables camera or denies access to it, a javascript error is displayed in the console and the meeting does not start. This PR solves this bug.

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-229325