### PR TITLE
fix(MeetingSdkAdapter): share button doesn't update the display

### DIFF
--- a/src/MeetingsSDKAdapter.test.js
+++ b/src/MeetingsSDKAdapter.test.js
@@ -2,19 +2,21 @@ import * as rxjs from 'rxjs';
 import {flatMap, take} from 'rxjs/operators';
 
 import MeetingSDKAdapter from './MeetingsSDKAdapter';
-import createMockSDK, {mockSDKMeeting} from './mockSdk';
+import createMockSDK from './mockSdk';
 
 describe('Meetings SDK Adapter', () => {
   let meeting;
   let meetingID;
   let meetingSDKAdapter;
   let mockSDK;
+  let mockSDKMeeting;
   let target;
 
   beforeEach(() => {
     mockSDK = createMockSDK();
-    meetingSDKAdapter = new MeetingSDKAdapter(mockSDK);
     meetingID = 'meetingID';
+    mockSDKMeeting = mockSDK.meetings.getMeetingByType('id', meetingID);
+    meetingSDKAdapter = new MeetingSDKAdapter(mockSDK);
     rxjs.fromEvent = jest.fn(() => rxjs.of({}));
     meeting = {
       ID: meetingID,
@@ -34,6 +36,7 @@ describe('Meetings SDK Adapter', () => {
     meeting = null;
     rxjs.fromEvent = null;
     mockSDK = null;
+    mockSDKMeeting = null;
     meetingSDKAdapter = null;
     meetingID = null;
     target = null;
@@ -641,6 +644,7 @@ describe('Meetings SDK Adapter', () => {
   describe('shareControl()', () => {
     test('returns the display data of a meeting control in a proper shape', (done) => {
       global.console.log = jest.fn();
+      meetingSDKAdapter.meetings[meetingID] = {...meeting};
 
       meetingSDKAdapter.shareControl(meetingID).subscribe((dataDisplay) => {
         expect(dataDisplay).toMatchObject({
@@ -656,10 +660,10 @@ describe('Meetings SDK Adapter', () => {
       global.console.log = jest.fn();
       meetingSDKAdapter.fetchMeeting = jest.fn();
 
-      meetingSDKAdapter.shareControl(meetingID).subscribe(
+      meetingSDKAdapter.shareControl('inexistent-meeting-id').subscribe(
         () => {},
         (error) => {
-          expect(error.message).toBe('Could not find meeting with ID "meetingID" to add share control');
+          expect(error.message).toBe('Could not find meeting with ID "inexistent-meeting-id" to add share control');
           done();
         },
       );
@@ -671,11 +675,6 @@ describe('Meetings SDK Adapter', () => {
     let stopStream;
 
     beforeEach(() => {
-      meetingSDKAdapter.meetings[meetingID] = {
-        ...meeting,
-        localShare: {},
-        remoteShare: {},
-      };
       const {trueStopStream} = meetingSDKAdapter.stopStream;
 
       stopStream = trueStopStream;
@@ -701,7 +700,7 @@ describe('Meetings SDK Adapter', () => {
     });
 
     test('start share if the share track is disabled', async () => {
-      meetingSDKAdapter.meetings[meetingID].localShare = null;
+      meetingSDKAdapter.meetings[meetingID] = {...meeting};
       const {getMediaStreams} = mockSDKMeeting;
 
       mockSDKMeeting.getMediaStreams = jest.fn(() => Promise.resolve([['mockStream'], 'localShare']));
@@ -713,14 +712,17 @@ describe('Meetings SDK Adapter', () => {
     });
 
     test('stop share if the share track is enabled', async () => {
-      meetingSDKAdapter.meetings[meetingID].localShare = 'localShare';
+      meetingSDKAdapter.meetings[meetingID] = {...meeting, localShare: 'localShare'};
       await meetingSDKAdapter.handleLocalShare(meetingID);
 
-      expect(mockSDKMeeting.updateShare).toHaveBeenCalled();
-      expect(meetingSDKAdapter.meetings[meetingID].localShare).toBeNull();
+      expect(mockSDKMeeting.updateShare).toHaveBeenCalledWith({
+        sendShare: false,
+        receiveShare: true,
+      });
     });
 
     test('resets sharing stream if share control is not handled properly', async () => {
+      meetingSDKAdapter.meetings[meetingID] = {...meeting, localShare: 'localShare'};
       global.console.warn = mockConsole;
       mockSDKMeeting.updateShare = jest.fn(() => Promise.reject());
       await meetingSDKAdapter.handleLocalShare(meetingID);

--- a/src/mockSdk.js
+++ b/src/mockSdk.js
@@ -14,7 +14,12 @@ export const mockSDKPerson = {
   orgId: 'orgID',
 };
 
-export const mockSDKMeeting = {
+/**
+ * Creates a mock instance of the Webex SDK Meeting used in unit testing
+ *
+ * @returns {object} mockSDKMeeting Instance
+ */
+export const createMockSDKMeeting = () => ({
   id: 'meetingID',
   sipuri: 'my meeting',
   members: {
@@ -97,7 +102,7 @@ export const mockSDKMeeting = {
   unmuteVideo: jest.fn(() => Promise.resolve()),
   canUpdateMedia: jest.fn(() => true),
   updateShare: jest.fn(() => Promise.resolve()),
-};
+});
 
 export const mockSDKMembership = {
   id: 'id',
@@ -122,6 +127,8 @@ export const mockSDKOrganization = {
  * @returns {object} mockSDK Instance
  */
 export default function createMockSDK() {
+  const mockSDKMeeting = createMockSDKMeeting();
+
   return {
     rooms: {
       get: jest.fn(() => Promise.resolve(mockSDKRoom)),


### PR DESCRIPTION
Fix the local share property to be updated  depending on the sdk event when the local share is stopped.
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-233449