### PR TITLE
feat(MeetingsSdkAdapter): allow switching camera after joining the meeting

### DIFF
--- a/src/MeetingsSDKAdapter.js
+++ b/src/MeetingsSDKAdapter.js
@@ -1108,6 +1108,13 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
 
     if (localVideo) {
       Object.assign(this.meetings[ID], {localVideo, cameraID});
+      if (this.meetings[ID].state === MeetingState.JOINED) {
+        await sdkMeeting.updateVideo({
+          stream: localVideo,
+          receiveVideo: mediaSettings.receiveVideo,
+          sendVideo: mediaSettings.sendVideo,
+        });
+      }
       sdkMeeting.emit(EVENT_CAMERA_SWITCH, {cameraID});
     } else {
       throw new Error('Could not change camera, permission not granted:', permission);


### PR DESCRIPTION
Update the SDK meeting by calling the .updateVideo method for a live-switching camera effect.

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-247118