### PR TITLE
feat(MeetingsSdkAdapter): allow switching microphone after joining the meeting

### DIFF
--- a/src/MeetingsSDKAdapter.js
+++ b/src/MeetingsSDKAdapter.js
@@ -1140,6 +1140,13 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
 
     if (localAudio) {
       Object.assign(this.meetings[ID], {localAudio, microphoneID});
+      if (this.meetings[ID].state === MeetingState.JOINED) {
+        await sdkMeeting.updateAudio({
+          stream: localAudio,
+          receiveAudio: mediaSettings.receiveAudio,
+          sendAudio: mediaSettings.sendAudio,
+        });
+      }
       sdkMeeting.emit(EVENT_MICROPHONE_SWITCH, {microphoneID});
     } else {
       throw new Error('Could not change microphone, permission not granted:', permission);


### PR DESCRIPTION
Update the SDK meeting by calling the .updateAudio method for a live-switching microphone effect.

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-247114