### PR TITLE
fix(MeetingsSdkAdapter): use getMeeting for audio and video controls

### DIFF
--- a/src/MeetingsSDKAdapter.test.js
+++ b/src/MeetingsSDKAdapter.test.js
@@ -554,12 +554,10 @@ describe('Meetings SDK Adapter', () => {
     });
 
     test('throws errors if sdk meeting object is not defined', (done) => {
-      meetingSDKAdapter.fetchMeeting = jest.fn();
-
-      meetingSDKAdapter.audioControl(meetingID).subscribe(
+      meetingSDKAdapter.audioControl('inexistent').subscribe(
         () => {},
         (error) => {
-          expect(error.message).toBe('Could not find meeting with ID "meetingID" to add audio control');
+          expect(error.message).toBe('Could not find meeting with ID "inexistent"');
           done();
         },
       );
@@ -667,12 +665,10 @@ describe('Meetings SDK Adapter', () => {
     });
 
     test('throws errors if sdk meeting object is not defined', (done) => {
-      meetingSDKAdapter.fetchMeeting = jest.fn();
-
-      meetingSDKAdapter.videoControl(meetingID).subscribe(
+      meetingSDKAdapter.videoControl('inexistent').subscribe(
         () => {},
         (error) => {
-          expect(error.message).toBe('Could not find meeting with ID "meetingID" to add video control');
+          expect(error.message).toBe('Could not find meeting with ID "inexistent"');
           done();
         },
       );


### PR DESCRIPTION
This Pr is for using the getMeeting adapter function for the audio and video controls

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-250022