### PR TITLE
feat(MeetingSdkAdapter): implement roster control in its own file and create the tests accordingly

### DIFF
--- a/src/MeetingsSDKAdapter.test.js
+++ b/src/MeetingsSDKAdapter.test.js
@@ -854,58 +854,29 @@ describe('Meetings SDK Adapter', () => {
     });
   });
 
-  describe('rosterControl()', () => {
-    test('returns the display data of a meeting control in a proper shape', (done) => {
-      meetingSDKAdapter.rosterControl(meetingID).subscribe((dataDisplay) => {
-        try {
-          expect(dataDisplay).toMatchObject({
-            ID: 'member-roster',
-            icon: 'participant-list_28',
-            tooltip: 'Show participants panel',
-            state: 'inactive',
-            text: 'Participants',
-          });
-          done();
-        } catch (error) {
-          done(error);
-        }
-      });
+  describe('toggleRoster()', () => {
+    test('shows roster is roster is hidden', async () => {
+      meetingSDKAdapter.meetings[meetingID].showRoster = false;
+      await meetingSDKAdapter.toggleRoster(meetingID);
+
+      expect(mockSDKMeeting.emit).toHaveBeenCalledTimes(1);
+      expect(mockSDKMeeting.emit.mock.calls[0][0]).toBe('adapter:meeting:updated');
+      expect(mockSDKMeeting.emit.mock.calls[0][1]).toMatchObject({showRoster: true});
     });
 
-    test('throws errors if sdk meeting object is not defined', (done) => {
-      meetingSDKAdapter.fetchMeeting = jest.fn();
-
-      meetingSDKAdapter.rosterControl(meetingID).subscribe(
-        () => {},
-        (error) => {
-          expect(error.message).toBe('Could not find meeting with ID "meetingID" to add roster control');
-          done();
-        },
-      );
-    });
-  });
-
-  describe('handleRoster()', () => {
-    beforeEach(() => {
-      meetingSDKAdapter.meetings[meetingID] = {
-        showRoster: null,
-      };
-    });
-
-    test('emits the roster toggle event with active state', async () => {
-      await meetingSDKAdapter.handleRoster(meetingID);
-
-      expect(mockSDKMeeting.emit).toHaveBeenCalledWith('adapter:roster:toggle', {
-        state: 'active',
-      });
-    });
-
-    test('emits the roster toggle event with inactive state', async () => {
+    test('hides roster if roster is shown', async () => {
       meetingSDKAdapter.meetings[meetingID].showRoster = true;
-      await meetingSDKAdapter.handleRoster(meetingID);
+      await meetingSDKAdapter.toggleRoster(meetingID);
 
-      expect(mockSDKMeeting.emit).toHaveBeenCalledWith('adapter:roster:toggle', {
-        state: 'inactive',
+      expect(mockSDKMeeting.emit).toHaveBeenCalledTimes(1);
+      expect(mockSDKMeeting.emit.mock.calls[0][0]).toBe('adapter:meeting:updated');
+      expect(mockSDKMeeting.emit.mock.calls[0][1]).toMatchObject({showRoster: false});
+    });
+
+    test('returns a rejected promise if meeting does not exist', (done) => {
+      meetingSDKAdapter.toggleRoster('inexistent').catch((error) => {
+        expect(error.message).toBe('Could not find meeting with ID "inexistent"');
+        done();
       });
     });
   });

--- a/src/MeetingsSDKAdapter/controls/MeetingControl.js
+++ b/src/MeetingsSDKAdapter/controls/MeetingControl.js
@@ -1,0 +1,12 @@
+export default class MeetingControl {
+  /**
+   * Creates a new instance of the MeetingControl.
+   *
+   * @param {object} adapter  Meeting adapter object
+   * @param {string} controlID  The id of the control
+   */
+  constructor(adapter, controlID) {
+    this.adapter = adapter;
+    this.ID = controlID;
+  }
+}

--- a/src/MeetingsSDKAdapter/controls/RosterControl.js
+++ b/src/MeetingsSDKAdapter/controls/RosterControl.js
@@ -1,0 +1,51 @@
+import {Observable} from 'rxjs';
+import {map, distinctUntilChanged} from 'rxjs/operators';
+import {MeetingControlState} from '@webex/component-adapter-interfaces';
+import MeetingControl from './MeetingControl';
+
+/**
+ * Display options of a meeting control.
+ *
+ * @external MeetingControlDisplay
+ * @see {@link https://github.com/webex/component-adapter-interfaces/blob/master/src/MeetingsAdapter.js#L58}
+ */
+
+export default class RosterControl extends MeetingControl {
+  /**
+   * Attempts to toggle roster to the given meeting ID.
+   * A roster toggle event is dispatched.
+   *
+   * @param {string} meetingID  Id of the meeting to toggle roster
+   */
+  action(meetingID) {
+    this.adapter.toggleRoster(meetingID);
+  }
+
+  /**
+   * Returns an observable that emits the display data of a roster control.
+   *
+   * @param {string} meetingID  Id of the meeting to toggle roster
+   * @returns {Observable.<MeetingControlDisplay>} Observable stream that emits display data of the roster control
+   */
+  display(meetingID) {
+    const active = {
+      ID: this.ID,
+      icon: 'participant-list_28',
+      tooltip: 'Hide participants panel',
+      state: MeetingControlState.ACTIVE,
+      text: 'Participants',
+    };
+    const inactive = {
+      ID: this.ID,
+      icon: 'participant-list_28',
+      tooltip: 'Show participants panel',
+      state: MeetingControlState.INACTIVE,
+      text: 'Participants',
+    };
+
+    return this.adapter.getMeeting(meetingID).pipe(
+      map(({showRoster}) => (showRoster ? active : inactive)),
+      distinctUntilChanged(),
+    );
+  }
+}

--- a/src/MeetingsSDKAdapter/controls/RosterControl.test.js
+++ b/src/MeetingsSDKAdapter/controls/RosterControl.test.js
@@ -1,0 +1,70 @@
+import {first} from 'rxjs/operators';
+import MeetingsSDKAdapter from '../../MeetingsSDKAdapter';
+import createMockSDK from '../../mockSdk';
+
+describe('Roster Control', () => {
+  let meeting;
+  let meetingID;
+  let meetingsSDKAdapter;
+  let mockSDK;
+
+  beforeEach(() => {
+    mockSDK = createMockSDK();
+    meetingID = 'meetingID';
+    meetingsSDKAdapter = new MeetingsSDKAdapter(mockSDK);
+    meeting = {
+      ID: meetingID,
+      localAudio: {
+        stream: null,
+        permission: null,
+      },
+      localShare: {
+        stream: null,
+      },
+      localVideo: {
+        stream: null,
+        permission: null,
+      },
+      remoteAudio: null,
+      remoteVideo: null,
+      remoteShare: null,
+      showRoster: null,
+      title: 'my meeting',
+      cameraID: null,
+      microphoneID: null,
+      speakerID: null,
+    };
+    meetingsSDKAdapter.meetings[meetingID] = meeting;
+  });
+
+  afterEach(() => {
+    meeting = null;
+    mockSDK = null;
+    meetingsSDKAdapter = null;
+    meetingID = null;
+  });
+
+  describe('display()', () => {
+    test('returns the display of a meeting control in a proper shape', () => {
+      meetingsSDKAdapter.meetingControls['member-roster'].display(meetingID).pipe(first())
+        .subscribe((dataDisplay) => {
+          expect(dataDisplay).toMatchObject({
+            ID: 'member-roster',
+            icon: 'participant-list_28',
+            tooltip: 'Show participants panel',
+            state: 'inactive',
+            text: 'Participants',
+          });
+        });
+    });
+  });
+
+  describe('action()', () => {
+    test('calls toggleRoster() SDK adapter method', async () => {
+      meetingsSDKAdapter.toggleRoster = jest.fn();
+      await meetingsSDKAdapter.meetingControls['member-roster'].action(meetingID);
+      expect(meetingsSDKAdapter.toggleRoster).toHaveBeenCalledTimes(1);
+      expect(meetingsSDKAdapter.toggleRoster).toHaveBeenCalledWith(meetingID);
+    });
+  });
+});

--- a/src/MeetingsSDKAdapter/controls/index.js
+++ b/src/MeetingsSDKAdapter/controls/index.js
@@ -1,0 +1,3 @@
+/* eslint-disable import/prefer-default-export */
+export {default as MeetingControl} from './MeetingControl';
+export {default as RosterControl} from './RosterControl';


### PR DESCRIPTION
For better encapsulation and code that is easier to maintain, the roster control functions (display & action) have been moved from the main meetings adapter file to individual files that are easier to read and maintain (eg. src/MeetingsSDKAdapter/controls/RosterControl.js). A test file for this functions has also been created.

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-242543