### PR TITLE
feat(MeetingSdkAdapter): implement settings control in its own file and create the tests accordingly

### DIFF
--- a/src/MeetingsSDKAdapter.test.js
+++ b/src/MeetingsSDKAdapter.test.js
@@ -40,6 +40,7 @@ describe('Meetings SDK Adapter', () => {
       remoteVideo: null,
       remoteShare: null,
       showRoster: null,
+      showSettings: false,
       title: 'my meeting',
       cameraID: null,
       microphoneID: null,
@@ -875,6 +876,31 @@ describe('Meetings SDK Adapter', () => {
 
     test('returns a rejected promise if meeting does not exist', (done) => {
       meetingSDKAdapter.toggleRoster('inexistent').catch((error) => {
+        expect(error.message).toBe('Could not find meeting with ID "inexistent"');
+        done();
+      });
+    });
+  });
+
+  describe('toggleSettings()', () => {
+    test('shows settings if settings is hidden', async () => {
+      meetingSDKAdapter.meetings[meetingID].showSettings = false;
+      await meetingSDKAdapter.toggleSettings(meetingID);
+      expect(mockSDKMeeting.emit).toHaveBeenCalledTimes(1);
+      expect(mockSDKMeeting.emit.mock.calls[0][0]).toBe('adapter:meeting:updated');
+      expect(mockSDKMeeting.emit.mock.calls[0][1]).toMatchObject({showSettings: true});
+    });
+
+    test('hides settings if settings is shown', async () => {
+      meetingSDKAdapter.meetings[meetingID].showSettings = true;
+      await meetingSDKAdapter.toggleSettings(meetingID);
+      expect(mockSDKMeeting.emit).toHaveBeenCalledTimes(1);
+      expect(mockSDKMeeting.emit.mock.calls[0][0]).toBe('adapter:meeting:updated');
+      expect(mockSDKMeeting.emit.mock.calls[0][1]).toMatchObject({showSettings: false});
+    });
+
+    test('returns a rejected promise if meeting does not exist', (done) => {
+      meetingSDKAdapter.toggleSettings('inexistent').catch((error) => {
         expect(error.message).toBe('Could not find meeting with ID "inexistent"');
         done();
       });

--- a/src/MeetingsSDKAdapter/controls/SettingsControl.js
+++ b/src/MeetingsSDKAdapter/controls/SettingsControl.js
@@ -1,0 +1,51 @@
+import {Observable} from 'rxjs';
+import {map, distinctUntilChanged} from 'rxjs/operators';
+import {MeetingControlState} from '@webex/component-adapter-interfaces';
+import MeetingControl from './MeetingControl';
+
+/**
+ * Display options of a meeting control.
+ *
+ * @external MeetingControlDisplay
+ * @see {@link https://github.com/webex/component-adapter-interfaces/blob/master/src/MeetingsAdapter.js#L58}
+ */
+
+export default class SettingsControl extends MeetingControl {
+  /**
+   * Toggles the showSettings flag of the given meeting ID.
+   * A settings toggle event is dispatched.
+   *
+   * @param {string} meetingID  Meeting ID
+   */
+  action(meetingID) {
+    this.adapter.toggleSettings(meetingID);
+  }
+
+  /**
+   * Returns an observable that emits the display data of a settings control.
+   *
+   * @param {string} meetingID  Meeting id
+   * @returns {Observable.<MeetingControlDisplay>} Observable stream that emits display data of the settings control
+   */
+  display(meetingID) {
+    const active = {
+      ID: this.ID,
+      icon: 'settings_32',
+      tooltip: 'Hide settings panel',
+      state: MeetingControlState.ACTIVE,
+      text: 'Settings',
+    };
+    const inactive = {
+      ID: this.ID,
+      icon: 'settings_32',
+      tooltip: 'Show settings panel',
+      state: MeetingControlState.INACTIVE,
+      text: 'Settings',
+    };
+
+    return this.adapter.getMeeting(meetingID).pipe(
+      map(({showSettings}) => (showSettings ? active : inactive)),
+      distinctUntilChanged(),
+    );
+  }
+}

--- a/src/MeetingsSDKAdapter/controls/SettingsControl.test.js
+++ b/src/MeetingsSDKAdapter/controls/SettingsControl.test.js
@@ -1,0 +1,71 @@
+import {first} from 'rxjs/operators';
+import MeetingsSDKAdapter from '../../MeetingsSDKAdapter';
+import createMockSDK from '../../mockSdk';
+
+describe('Settings Control', () => {
+  let meeting;
+  let meetingID;
+  let meetingsSDKAdapter;
+  let mockSDK;
+
+  beforeEach(() => {
+    mockSDK = createMockSDK();
+    meetingID = 'meetingID';
+    meetingsSDKAdapter = new MeetingsSDKAdapter(mockSDK);
+    meeting = {
+      ID: meetingID,
+      localAudio: {
+        stream: null,
+        permission: null,
+      },
+      localShare: {
+        stream: null,
+      },
+      localVideo: {
+        stream: null,
+        permission: null,
+      },
+      remoteAudio: null,
+      remoteVideo: null,
+      remoteShare: null,
+      showRoster: null,
+      showSettings: false,
+      title: 'my meeting',
+      cameraID: null,
+      microphoneID: null,
+      speakerID: null,
+    };
+    meetingsSDKAdapter.meetings[meetingID] = meeting;
+  });
+
+  afterEach(() => {
+    meeting = null;
+    mockSDK = null;
+    meetingsSDKAdapter = null;
+    meetingID = null;
+  });
+
+  describe('display()', () => {
+    test('returns the display data of a meeting control in a proper shape', () => {
+      meetingsSDKAdapter.meetingControls.settings.display(meetingID).pipe(first())
+        .subscribe((dataDisplay) => {
+          expect(dataDisplay).toMatchObject({
+            ID: 'settings',
+            icon: 'settings_32',
+            tooltip: 'Show settings panel',
+            state: 'inactive',
+            text: 'Settings',
+          });
+        });
+    });
+  });
+
+  describe('action()', () => {
+    test('calls toggleSettings() SDK adapter method', async () => {
+      meetingsSDKAdapter.toggleSettings = jest.fn();
+      await meetingsSDKAdapter.meetingControls.settings.action(meetingID);
+      expect(meetingsSDKAdapter.toggleSettings).toHaveBeenCalledTimes(1);
+      expect(meetingsSDKAdapter.toggleSettings).toHaveBeenCalledWith(meetingID);
+    });
+  });
+});

--- a/src/MeetingsSDKAdapter/controls/index.js
+++ b/src/MeetingsSDKAdapter/controls/index.js
@@ -1,3 +1,4 @@
 /* eslint-disable import/prefer-default-export */
 export {default as MeetingControl} from './MeetingControl';
 export {default as RosterControl} from './RosterControl';
+export {default as SettingsControl} from './SettingsControl';


### PR DESCRIPTION
For better encapsulation and code that is easier to maintain, the settings control functions (display & action) have been moved from the main meetings adapter file to individual files that are easier to read and maintain (eg. src/MeetingsSDKAdapter/controls/SettingsControl.js). A test file for this functions has also been created.

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-251784