### PR TITLE
feat(MeetingSdkAdapter): implement join control in its own file and create the tests accordingly

### DIFF
--- a/src/MeetingsSDKAdapter.js
+++ b/src/MeetingsSDKAdapter.js
@@ -22,6 +22,7 @@ import {
 } from 'rxjs/operators';
 
 import ExitControl from './MeetingsSDKAdapter/controls/ExitControl';
+import JoinControl from './MeetingsSDKAdapter/controls/JoinControl';
 import RosterControl from './MeetingsSDKAdapter/controls/RosterControl';
 import SettingsControl from './MeetingsSDKAdapter/controls/SettingsControl';
 import {chainWith} from './utils';
@@ -111,11 +112,7 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
     this.getMeetingObservables = {};
     this.meetings = {};
 
-    this.meetingControls[JOIN_CONTROL] = {
-      ID: JOIN_CONTROL,
-      action: this.joinMeeting.bind(this),
-      display: this.joinControl.bind(this),
-    };
+    this.meetingControls[JOIN_CONTROL] = new JoinControl(this, JOIN_CONTROL);
 
     this.meetingControls[AUDIO_CONTROL] = {
       ID: AUDIO_CONTROL,
@@ -613,26 +610,6 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
       // eslint-disable-next-line no-console
       console.error(`Unable to leave from the meeting "${ID}"`, error);
     }
-  }
-
-  /**
-   * Returns an observable that emits the display data of a meeting control.
-   *
-   * @private
-   * @returns {Observable.<MeetingControlDisplay>} Observable stream that emits display data of the join control
-   */
-  // eslint-disable-next-line class-methods-use-this
-  joinControl() {
-    return Observable.create((observer) => {
-      observer.next({
-        ID: JOIN_CONTROL,
-        text: 'Join meeting',
-        tooltip: 'Join meeting',
-        state: MeetingControlState.ACTIVE,
-      });
-
-      observer.complete();
-    });
   }
 
   /**

--- a/src/MeetingsSDKAdapter/controls/JoinControl.js
+++ b/src/MeetingsSDKAdapter/controls/JoinControl.js
@@ -1,0 +1,36 @@
+import {Observable, of} from 'rxjs';
+import {MeetingControlState} from '@webex/component-adapter-interfaces';
+import MeetingControl from './MeetingControl';
+
+/**
+ * Display options of a meeting control.
+ *
+ * @external MeetingControlDisplay
+ * @see {@link https://github.com/webex/component-adapter-interfaces/blob/master/src/MeetingsAdapter.js#L58}
+ */
+
+export default class JoinControl extends MeetingControl {
+  /**
+   * Calls the adapter joinMeeting method.
+   *
+   * @param {string} meetingID  Id of the meeting to join
+   */
+  async action(meetingID) {
+    await this.adapter.joinMeeting(meetingID);
+  }
+
+  /**
+   * Returns an observable that emits the display data of the control.
+   *
+   * @returns {Observable.<MeetingControlDisplay>} Observable that emits display of the join control
+   */
+  // eslint-disable-next-line class-methods-use-this
+  display() {
+    return of({
+      ID: this.ID,
+      text: 'Join meeting',
+      tooltip: 'Join meeting',
+      state: MeetingControlState.ACTIVE,
+    });
+  }
+}

--- a/src/MeetingsSDKAdapter/controls/JoinControl.test.js
+++ b/src/MeetingsSDKAdapter/controls/JoinControl.test.js
@@ -1,0 +1,36 @@
+import {first} from 'rxjs/operators';
+import {meetingID, createTestMeetingsSDKAdapter} from '../testHelper';
+
+describe('Join Control', () => {
+  let meetingsSDKAdapter;
+
+  beforeEach(() => {
+    meetingsSDKAdapter = createTestMeetingsSDKAdapter();
+  });
+
+  afterEach(() => {
+    meetingsSDKAdapter = null;
+  });
+
+  describe('display()', () => {
+    test('returns the display data in a proper shape', (done) => {
+      meetingsSDKAdapter.meetingControls['join-meeting'].display().pipe(first()).subscribe((display) => {
+        expect(display).toMatchObject({
+          ID: 'join-meeting',
+          text: 'Join meeting',
+          tooltip: 'Join meeting',
+          state: 'active',
+        });
+        done();
+      });
+    });
+  });
+
+  describe('action()', () => {
+    test('calls joinMeeting() SDK adapter method', async () => {
+      meetingsSDKAdapter.joinMeeting = jest.fn();
+      await meetingsSDKAdapter.meetingControls['join-meeting'].action(meetingID);
+      expect(meetingsSDKAdapter.joinMeeting).toHaveBeenCalledWith(meetingID);
+    });
+  });
+});

--- a/src/MeetingsSDKAdapter/controls/index.js
+++ b/src/MeetingsSDKAdapter/controls/index.js
@@ -1,4 +1,5 @@
 /* eslint-disable import/prefer-default-export */
+export {default as JoinControl} from './JoinControl';
 export {default as MeetingControl} from './MeetingControl';
 export {default as RosterControl} from './RosterControl';
 export {default as SettingsControl} from './SettingsControl';

--- a/src/mockSdk.js
+++ b/src/mockSdk.js
@@ -102,6 +102,7 @@ export const createMockSDKMeeting = () => ({
   },
   addMedia: jest.fn(() => Promise.resolve()),
   emit: jest.fn(() => Promise.resolve()),
+  getDevices: jest.fn(() => Promise.resolve([])),
   getMediaStreams: jest.fn((constraint) => {
     const mockSDKMediaStreams = createMockSDKMediaStreams();
 


### PR DESCRIPTION
For better encapsulation and code that is easier to maintain, the join control functions (display & action) have been moved from the main meetings adapter file to individual files that are easier to read and maintain (eg. src/MeetingsSDKAdapter/controls/JoinControl.js). A test file for this functions has also been created.