### PR TITLE
feat(MeetingSdkAdapter): implement switch speaker  in its own file and create the tests accordingly

### DIFF
--- a/src/MeetingsSDKAdapter.test.js
+++ b/src/MeetingsSDKAdapter.test.js
@@ -916,47 +916,20 @@ describe('Meetings SDK Adapter', () => {
     });
   });
 
-  describe('switchSpeakerControl()', () => {
-    test('returns the display data of a meeting control in a proper shape', (done) => {
-      meetingsSDKAdapter.switchSpeakerControl(meetingID)
-        .pipe(first()).subscribe((dataDisplay) => {
-          expect(dataDisplay).toMatchObject({
-            ID: 'switch-speaker',
-            type: 'MULTISELECT',
-            tooltip: 'Speaker Devices',
-            options: null,
-            selected: null,
-          });
-          done();
-        });
-    });
-
-    test('throws errors if sdk meeting object is not defined', (done) => {
-      meetingsSDKAdapter.fetchMeeting = jest.fn();
-
-      meetingsSDKAdapter.switchSpeakerControl(meetingID).subscribe(
-        () => {},
-        (error) => {
-          expect(error.message).toBe('Could not find meeting with ID "meetingID" to add switch speaker control');
-          done();
-        },
-      );
-    });
-  });
-
   describe('switchSpeaker()', () => {
-    beforeEach(() => {
-      meetingsSDKAdapter.meetings[meetingID] = {
-        ...meeting,
-        speakerID: null,
-      };
+    test('sets the speaker that was chosen by the user', async () => {
+      meetingsSDKAdapter.meetings[meetingID].speakerID = null;
+      await meetingsSDKAdapter.switchSpeaker(meetingID, 'example-speaker-id');
+
+      expect(mockSDKMeeting.emit).toHaveBeenCalledTimes(1);
+      expect(mockSDKMeeting.emit.mock.calls[0][0]).toBe('adapter:meeting:updated');
+      expect(mockSDKMeeting.emit.mock.calls[0][1]).toMatchObject({speakerID: 'example-speaker-id'});
     });
 
-    test('emits the switch speaker events with speakerID', async () => {
-      await meetingsSDKAdapter.switchSpeaker(meetingID, 'speakerID');
-
-      expect(mockSDKMeeting.emit).toHaveBeenCalledWith('adapter:speaker:switch', {
-        speakerID: 'speakerID',
+    test('returns a rejected promise if meeting does not exist', (done) => {
+      meetingsSDKAdapter.switchSpeaker('inexistent', 'example-speaker-id').catch((error) => {
+        expect(error.message).toBe('Could not find meeting with ID "inexistent"');
+        done();
       });
     });
   });

--- a/src/MeetingsSDKAdapter/controls/SwitchSpeakerControl.js
+++ b/src/MeetingsSDKAdapter/controls/SwitchSpeakerControl.js
@@ -1,0 +1,54 @@
+import {
+  defer,
+  Observable,
+} from 'rxjs';
+import {map, distinctUntilChanged} from 'rxjs/operators';
+import MeetingControl from './MeetingControl';
+import {combineLatestImmediate} from '../../utils';
+/**
+ * Display options of a meeting control.
+ *
+ * @external MeetingControlDisplay
+ * @see {@link https://github.com/webex/component-adapter-interfaces/blob/master/src/MeetingsAdapter.js#L58}
+ */
+
+export default class SwitchSpeakerControl extends MeetingControl {
+  /**
+   * Calls the the action of the switch speaker control.
+   *
+   * @param {string} meetingID  Meeting ID
+   * @param {string} speakerID  ID of the speaker device to switch to
+   */
+  async action(meetingID, speakerID) {
+    await this.adapter.switchSpeaker(meetingID, speakerID);
+  }
+
+  /**
+   * Returns and observable that emits the display data of the control.
+   *
+   * @param {string} meetingID  Meeting ID
+   * @returns {Observable.<MeetingControlDisplay>} Observable that emits control display of the control
+   */
+  display(meetingID) {
+    const speakerID$ = this.adapter.getMeeting(meetingID).pipe(
+      map((meeting) => meeting.speakerID),
+      distinctUntilChanged(),
+    );
+    const options$ = defer(() => this.adapter.getAvailableDevices(meetingID, 'audiooutput')).pipe(
+      map((availableSpeakers) => availableSpeakers.map((speaker) => ({
+        value: speaker.deviceId,
+        label: speaker.label,
+      }))),
+    );
+
+    return combineLatestImmediate(speakerID$, options$).pipe(
+      map(([speakerID, options]) => ({
+        ID: this.ID,
+        tooltip: 'Speaker Devices',
+        noOptionsMessage: 'No available speakers',
+        options: options || null,
+        selected: speakerID || null,
+      })),
+    );
+  }
+}

--- a/src/MeetingsSDKAdapter/controls/SwitchSpeakerControl.test.js
+++ b/src/MeetingsSDKAdapter/controls/SwitchSpeakerControl.test.js
@@ -1,0 +1,63 @@
+import {elementAt} from 'rxjs/operators';
+import {meetingID, createTestMeetingsSDKAdapter} from '../testHelper';
+
+describe('Switch Speaker Control', () => {
+  let meetingsSDKAdapter;
+
+  beforeEach(() => {
+    meetingsSDKAdapter = createTestMeetingsSDKAdapter();
+  });
+
+  afterEach(() => {
+    meetingsSDKAdapter = null;
+  });
+
+  describe('display()', () => {
+    test('return the display data in a proper shape', (done) => {
+      meetingsSDKAdapter.meetingControls['switch-speaker'].display(meetingID)
+        .pipe(elementAt(1)).subscribe((display) => {
+          expect(display).toMatchObject({
+            ID: 'switch-speaker',
+            tooltip: 'Speaker Devices',
+            noOptionsMessage: 'No available speakers',
+            options: [
+              {
+                value: 'default',
+                label: 'Default - Headset Earphone (Jabra EVOLVE 20 SE MS) (0b0e:0300)',
+              },
+              {
+                value: 'communications',
+                label: 'Communications - Headset Earphone (Jabra EVOLVE 20 SE MS) (0b0e:0300)',
+              },
+              {
+                value: '5e2cade11fab305ca3773e507b06e60d0a65ed8d6a19da2927a287c70e713dc7',
+                label: 'Line (Realtek USB2.0 Audio) (0bda:402e)',
+              },
+              {
+                value: '91e9c4b27e0b7bc8f41f3076a66e2968d4e229a5f388c2fe9f251bf8d54d7a34',
+                label: 'Headphones (Realtek USB2.0 Audio) (0bda:402e)',
+              },
+              {
+                value: 'a2f1a439c64a73b712a54c16f77716fb6040d87de312d211ef886944877ecea2',
+                label: 'Speakers (Realtek(R) Audio)',
+              },
+              {
+                value: '85e52fb55424206524719fab873ea7c3419c496ce1f691a009066ada5feaf813',
+                label: 'Headset Earphone (Jabra EVOLVE 20 SE MS) (0b0e:0300)',
+              },
+            ],
+            selected: 'speakerID',
+          });
+          done();
+        });
+    });
+  });
+
+  describe('action()', () => {
+    test('calls switchSpeaker() SDK adapter method', async () => {
+      meetingsSDKAdapter.switchSpeaker = jest.fn();
+      await meetingsSDKAdapter.meetingControls['switch-speaker'].action(meetingID, 'speakerID');
+      expect(meetingsSDKAdapter.switchSpeaker).toHaveBeenCalledWith(meetingID, 'speakerID');
+    });
+  });
+});

--- a/src/MeetingsSDKAdapter/controls/index.js
+++ b/src/MeetingsSDKAdapter/controls/index.js
@@ -8,3 +8,4 @@ export {default as RosterControl} from './RosterControl';
 export {default as SettingsControl} from './SettingsControl';
 export {default as SwitchCameraControl} from './SwitchCameraControl';
 export {default as SwitchMicrophoneControl} from './SwitchMicrophoneControl';
+export {default as SwitchSpeakerControl} from './SwitchSpeakerControl';

--- a/src/MeetingsSDKAdapter/testHelper.js
+++ b/src/MeetingsSDKAdapter/testHelper.js
@@ -30,7 +30,7 @@ export function createTestMeetingsSDKAdapter() {
     title: 'my meeting',
     cameraID: 'cameraID',
     microphoneID: null,
-    speakerID: null,
+    speakerID: 'speakerID',
   };
   const mockSDK = createMockSDK();
   const meetingsSDKAdapter = new MeetingsSDKAdapter(mockSDK);


### PR DESCRIPTION
For better encapsulation and code that is easier to maintain, the switch speaker control functions (display & action) have been moved from the main meetings adapter file to individual files that are easier to read and maintain (eg. src/MeetingsSDKAdapter/controls/SwitchSpeakerControl.js). A test file for this functions has also been created.

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-252483