### PR TITLE
feat(MeetingsSdkAdapter): move audio control in a separate file

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,6 +1,6 @@
 // Mock Web Media APIs
 
-global.MediaStream = jest.fn((tracksOrStream = []) => {
+global.MediaStream = jest.fn(function(tracksOrStream = []) {
   let tracks;
 
   if (tracksOrStream instanceof global.MediaStream) {
@@ -22,12 +22,12 @@ global.MediaStream = jest.fn((tracksOrStream = []) => {
     }
   }
 
-  return {
+  return Object.assign(this, {
     getTracks: jest.fn(() => tracks),
     getAudioTracks: jest.fn(() => tracks.filter((track) => track.kind === 'audio')),
     getVideoTracks: jest.fn(() => tracks.filter((track) => track.kind === 'video')),
     removeTrack: jest.fn((toRemove) => tracks.filter((track) => track !== toRemove)),
-  };
+  });
 });
 
 expect.extend({

--- a/src/MeetingsSDKAdapter/controls/AudioControl.js
+++ b/src/MeetingsSDKAdapter/controls/AudioControl.js
@@ -1,0 +1,61 @@
+import {Observable} from 'rxjs';
+import {map, distinctUntilChanged} from 'rxjs/operators';
+import {MeetingControlState} from '@webex/component-adapter-interfaces';
+import MeetingControl from './MeetingControl';
+
+/**
+ * Display options of a meeting control.
+ *
+ * @external MeetingControlDisplay
+ * @see {@link https://github.com/webex/component-adapter-interfaces/blob/master/src/MeetingsAdapter.js#L58}
+ */
+
+export default class AudioControl extends MeetingControl {
+  /**
+   * Calls the adapter handleLocalAudio() method
+   *
+   * @private
+   * @param {string} meetingID  ID of the meeting to mute audio
+   */
+  action(meetingID) {
+    return this.adapter.handleLocalAudio(meetingID);
+  }
+
+  /**
+   * Returns an observable that emits the display data of a mute meeting audio control.
+   *
+   * @private
+   * @param {string} meetingID  ID of the meeting to mute audio
+   * @returns {Observable.<MeetingControlDisplay>} Observable stream that emits display data of the audio control
+   */
+  display(meetingID) {
+    const muted = {
+      ID: this.ID,
+      icon: 'microphone-muted_28',
+      tooltip: 'Unmute',
+      state: MeetingControlState.ACTIVE,
+      text: null,
+    };
+    const unmuted = {
+      ID: this.ID,
+      icon: 'microphone-muted_28',
+      tooltip: 'Mute',
+      state: MeetingControlState.INACTIVE,
+      text: null,
+    };
+    const disabled = {
+      ID: this.ID,
+      icon: 'microphone-muted_28',
+      tooltip: 'No microphone available',
+      state: MeetingControlState.DISABLED,
+      text: null,
+    };
+
+    return this.adapter.getMeeting(meetingID).pipe(
+      map(({localAudio: {stream}, disabledLocalAudio}) => (
+        (stream && unmuted) || (disabledLocalAudio && muted) || disabled
+      )),
+      distinctUntilChanged(),
+    );
+  }
+}

--- a/src/MeetingsSDKAdapter/controls/AudioControl.test.js
+++ b/src/MeetingsSDKAdapter/controls/AudioControl.test.js
@@ -1,0 +1,49 @@
+import {first} from 'rxjs/operators';
+import {meetingID, createTestMeetingsSDKAdapter} from '../testHelper';
+
+describe('Audio Control', () => {
+  let meetingsSDKAdapter;
+
+  beforeEach(() => {
+    meetingsSDKAdapter = createTestMeetingsSDKAdapter();
+  });
+
+  afterEach(() => {
+    meetingsSDKAdapter = null;
+  });
+
+  describe('display()', () => {
+    test('returns the display data in a proper shape', (done) => {
+      meetingsSDKAdapter.meetingControls['mute-audio'].display(meetingID).pipe(first())
+        .subscribe((dataDisplay) => {
+          expect(dataDisplay).toMatchObject({
+            ID: 'mute-audio',
+            icon: 'microphone-muted_28',
+            tooltip: 'No microphone available',
+            state: 'disabled',
+            text: null,
+          });
+          done();
+        });
+    });
+
+    test('emits an error if the meeting does not exist', (done) => {
+      meetingsSDKAdapter.meetingControls['mute-audio'].display('inexistent').subscribe(
+        () => {},
+        (error) => {
+          expect(error.message).toBe('Could not find meeting with ID "inexistent"');
+          done();
+        },
+      );
+    });
+  });
+
+  describe('action()', () => {
+    test('calls handleLocalAudio() SDK adapter method', async () => {
+      meetingsSDKAdapter.handleLocalAudio = jest.fn();
+      await meetingsSDKAdapter.meetingControls['mute-audio'].action(meetingID);
+      expect(meetingsSDKAdapter.handleLocalAudio).toHaveBeenCalledTimes(1);
+      expect(meetingsSDKAdapter.handleLocalAudio).toHaveBeenCalledWith(meetingID);
+    });
+  });
+});

--- a/src/MeetingsSDKAdapter/controls/index.js
+++ b/src/MeetingsSDKAdapter/controls/index.js
@@ -1,4 +1,5 @@
 /* eslint-disable import/prefer-default-export */
+export {default as AudioControl} from './AudioControl';
 export {default as JoinControl} from './JoinControl';
 export {default as MeetingControl} from './MeetingControl';
 export {default as RosterControl} from './RosterControl';

--- a/src/utils.js
+++ b/src/utils.js
@@ -40,4 +40,22 @@ export function chainWith(createDependentObservable) {
   });
 }
 
-export default {chainWith};
+/**
+ * Helper function for deep merge on objects.
+ *
+ * @param {object} dest - The destination object.
+ * @param {object} src - The source object.
+ */
+export function deepMerge(dest, src) {
+  const result = dest;
+
+  for (const [key, val] of Object.entries(src)) {
+    if (val && val.constructor === Object) {
+      deepMerge(result[key], val);
+    } else {
+      result[key] = val;
+    }
+  }
+}
+
+export default {chainWith, deepMerge};


### PR DESCRIPTION
For better encapsulation and code that is easier to maintain, the audio control functions (display & action) have been moved from the main meetings adapter file to individual files that are easier to read and maintain (eg. src/MeetingsSDKAdapter/controls/AudioControl.js). A test file for this functions has also been created.

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-252485