### PR TITLE
feat(MeetingsSdkAdapter): move proceed without microphone control in its own file and create tests

### DIFF
--- a/src/MeetingsSDKAdapter.js
+++ b/src/MeetingsSDKAdapter.js
@@ -24,6 +24,7 @@ import AudioControl from './MeetingsSDKAdapter/controls/AudioControl';
 import ExitControl from './MeetingsSDKAdapter/controls/ExitControl';
 import JoinControl from './MeetingsSDKAdapter/controls/JoinControl';
 import ProceedWithoutCameraControl from './MeetingsSDKAdapter/controls/ProceedWithoutCameraControl';
+import ProceedWithoutMicrophoneControl from './MeetingsSDKAdapter/controls/ProceedWithoutMicrophoneControl';
 import RosterControl from './MeetingsSDKAdapter/controls/RosterControl';
 import SettingsControl from './MeetingsSDKAdapter/controls/SettingsControl';
 import SwitchCameraControl from './MeetingsSDKAdapter/controls/SwitchCameraControl';
@@ -138,16 +139,13 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
     SwitchCameraControl(this, SWITCH_CAMERA_CONTROL);
     this.meetingControls[SWITCH_SPEAKER_CONTROL] = new
     SwitchSpeakerControl(this, SWITCH_SPEAKER_CONTROL);
+    this.meetingControls[PROCEED_WITHOUT_MICROPHONE_CONTROL] = new
+    ProceedWithoutMicrophoneControl(this, PROCEED_WITHOUT_MICROPHONE_CONTROL);
+
     this.meetingControls[SWITCH_MICROPHONE_CONTROL] = new
     SwitchMicrophoneControl(this, SWITCH_MICROPHONE_CONTROL);
     this.meetingControls[PROCEED_WITHOUT_CAMERA_CONTROL] = new
     ProceedWithoutCameraControl(this, PROCEED_WITHOUT_CAMERA_CONTROL);
-
-    this.meetingControls[PROCEED_WITHOUT_MICROPHONE_CONTROL] = {
-      ID: PROCEED_WITHOUT_MICROPHONE_CONTROL,
-      action: this.ignoreAudioAccessPrompt.bind(this),
-      display: this.proceedWithoutMicrophoneControl.bind(this),
-    };
   }
 
   /**
@@ -1041,36 +1039,9 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
   }
 
   /**
-   * Returns an observable that emits the display data of the proceed without microphone control.
-   *
-   * @param {string} ID  Meeting ID
-   * @returns {Observable.<MeetingControlDisplay>} Observable that emits control display data of proceed without microphone control
-   * @private
-   */
-  proceedWithoutMicrophoneControl(ID) {
-    const sdkMeeting = this.fetchMeeting(ID);
-
-    const control$ = new Observable((observer) => {
-      if (sdkMeeting) {
-        observer.next({
-          ID: PROCEED_WITHOUT_MICROPHONE_CONTROL,
-          type: 'JOIN',
-          text: 'Proceed without microphone',
-          tooltip: 'Ignore media access prompt and proceed without microphone',
-        });
-        observer.complete();
-      } else {
-        observer.error(new Error(`Could not find meeting with ID "${ID}" to add proceed without microphone control`));
-      }
-    });
-
-    return control$;
-  }
-
-  /**
    * Allows user to join meeting without allowing microphone access
    *
-   * @param {string} ID Meeting ID
+   * @param {string} ID  Meeting ID
    */
   ignoreAudioAccessPrompt(ID) {
     const meeting = this.meetings[ID];

--- a/src/MeetingsSDKAdapter.test.js
+++ b/src/MeetingsSDKAdapter.test.js
@@ -944,31 +944,6 @@ describe('Meetings SDK Adapter', () => {
     });
   });
 
-  describe('proceedWithoutMicrophoneControl()', () => {
-    test('returns the display data of a meeting control in a proper shape', (done) => {
-      meetingsSDKAdapter.proceedWithoutMicrophoneControl(meetingID)
-        .pipe(first()).subscribe((dataDisplay) => {
-          expect(dataDisplay).toMatchObject({
-            ID: 'proceed-without-microphone',
-            type: 'JOIN',
-            text: 'Proceed without microphone',
-            tooltip: 'Ignore media access prompt and proceed without microphone',
-          });
-          done();
-        });
-    });
-
-    test('throws errors if sdk meeting object is not defined', (done) => {
-      meetingsSDKAdapter.proceedWithoutMicrophoneControl('inexistent').subscribe(
-        () => {},
-        (error) => {
-          expect(error.message).toBe('Could not find meeting with ID "inexistent" to add proceed without microphone control');
-          done();
-        },
-      );
-    });
-  });
-
   describe('ignoreAudioAccessPrompt()', () => {
     test('calls ignoreAudioAccessPrompt() on the meeting object if defined', () => {
       meetingsSDKAdapter.meetings[meetingID].localAudio.ignoreMediaAccessPrompt = jest.fn();

--- a/src/MeetingsSDKAdapter/controls/ProceedWithoutMicrophoneControl.js
+++ b/src/MeetingsSDKAdapter/controls/ProceedWithoutMicrophoneControl.js
@@ -1,0 +1,47 @@
+import {
+  Observable,
+} from 'rxjs';
+import MeetingControl from './MeetingControl';
+
+/**
+ * Display options of a meeting control.
+ *
+ * @external MeetingControlDisplay
+ * @see {@link https://github.com/webex/component-adapter-interfaces/blob/master/src/MeetingsAdapter.js#L58}
+ */
+
+export default class ProceedWithoutMicrophoneControl extends MeetingControl {
+  /**
+   * Calls the adapter ignoreAudioAccessPrompt method.
+   *
+   * @param {string} meetingID  Meeting ID
+   */
+  async action(meetingID) {
+    await this.adapter.ignoreAudioAccessPrompt(meetingID);
+  }
+
+  /**
+   * Returns an observable that emits the display data of the proceed without microphone control.
+   *
+   * @param {string} meetingID  Meeting ID
+   * @returns {Observable.<MeetingControlDisplay>} Observable that emits control display data of proceed without microphone control
+   */
+  display(meetingID) {
+    const sdkMeeting = this.adapter.fetchMeeting(meetingID);
+
+    const control$ = new Observable((observer) => {
+      if (sdkMeeting) {
+        observer.next({
+          ID: this.ID,
+          text: 'Proceed without microphone',
+          tooltip: 'Ignore media access prompt and proceed without microphone',
+        });
+        observer.complete();
+      } else {
+        observer.error(new Error(`Could not find meeting with ID "${meetingID}" to add proceed without microphone control`));
+      }
+    });
+
+    return control$;
+  }
+}

--- a/src/MeetingsSDKAdapter/controls/ProceedWithoutMicrophoneControl.test.js
+++ b/src/MeetingsSDKAdapter/controls/ProceedWithoutMicrophoneControl.test.js
@@ -1,0 +1,46 @@
+import {first} from 'rxjs/operators';
+import {meetingID, createTestMeetingsSDKAdapter} from '../testHelper';
+
+describe('Proceed Without Microphone Control', () => {
+  let meetingsSDKAdapter;
+
+  beforeEach(() => {
+    meetingsSDKAdapter = createTestMeetingsSDKAdapter();
+  });
+
+  afterEach(() => {
+    meetingsSDKAdapter = null;
+  });
+
+  describe('display()', () => {
+    test('returns the display of a meeting control in a proper shape', (done) => {
+      meetingsSDKAdapter.meetingControls['proceed-without-microphone'].display(meetingID)
+        .pipe(first()).subscribe((display) => {
+          expect(display).toMatchObject({
+            ID: 'proceed-without-microphone',
+            text: 'Proceed without microphone',
+            tooltip: 'Ignore media access prompt and proceed without microphone',
+          });
+          done();
+        });
+    });
+
+    test('throws errors if sdk meeting object is not defined', (done) => {
+      meetingsSDKAdapter.meetingControls['proceed-without-microphone'].display('inexistent').subscribe(
+        () => {},
+        (error) => {
+          expect(error.message).toBe('Could not find meeting with ID "inexistent" to add proceed without microphone control');
+          done();
+        },
+      );
+    });
+  });
+
+  describe('action()', () => {
+    test('calls ignoreAudioAccessPrompt() SDK adapter method', async () => {
+      meetingsSDKAdapter.ignoreAudioAccessPrompt = jest.fn();
+      await meetingsSDKAdapter.meetingControls['proceed-without-microphone'].action(meetingID);
+      expect(meetingsSDKAdapter.ignoreAudioAccessPrompt).toHaveBeenCalledWith(meetingID);
+    });
+  });
+});

--- a/src/MeetingsSDKAdapter/controls/index.js
+++ b/src/MeetingsSDKAdapter/controls/index.js
@@ -4,6 +4,7 @@ export {default as ExitControl} from './ExitControl';
 export {default as JoinControl} from './JoinControl';
 export {default as MeetingControl} from './MeetingControl';
 export {default as ProceedWithoutCameraControl} from './ProceedWithoutCameraControl';
+export {default as ProceedWithoutMicrophoneControl} from './ProceedWithoutMicrophoneControl';
 export {default as RosterControl} from './RosterControl';
 export {default as SettingsControl} from './SettingsControl';
 export {default as SwitchCameraControl} from './SwitchCameraControl';


### PR DESCRIPTION
For better encapsulation and code that is easier to maintain, the proceed without microphone control functions (display & action) have been moved from the main meetings adapter file to individual files that are easier to read and maintain (eg. src/MeetingsSDKAdapter/controls/ProceedWithoutMicrophoneControl.js). A test file for this functions has also been created.

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-254407