### PR TITLE
fix(MeetingsAdapter): add edge case tests

### DIFF
--- a/src/MeetingsSDKAdapter.js
+++ b/src/MeetingsSDKAdapter.js
@@ -393,13 +393,19 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
    * @param {string} ID ID of the meeting to update
    */
   removeMedia(ID) {
-    if (this.meetings && this.meetings[ID]) {
-      this.stopStream(this.meetings[ID].localAudio.stream);
-      this.stopStream(this.meetings[ID].localVideo.stream);
-      this.stopStream(this.meetings[ID].localShare.stream);
-      this.stopStream(this.meetings[ID].disabledLocalAudio);
-      this.stopStream(this.meetings[ID].disabledLocalVideo);
+    const meeting = this.meetings[ID];
+
+    if (!meeting) {
+      return;
     }
+
+    const {localAudio, localVideo, localShare} = meeting;
+
+    this.stopStream(localAudio && localAudio.stream);
+    this.stopStream(localVideo && localVideo.stream);
+    this.stopStream(localShare && localShare.stream);
+    this.stopStream(meeting.disabledLocalAudio);
+    this.stopStream(meeting.disabledLocalVideo);
 
     this.meetings[ID] = {
       ...this.meetings[ID],

--- a/src/MeetingsSDKAdapter/testHelper.js
+++ b/src/MeetingsSDKAdapter/testHelper.js
@@ -4,6 +4,27 @@ import MeetingsSDKAdapter from '../MeetingsSDKAdapter';
 export const meetingID = 'meetingID';
 
 /**
+ * Shape of meeting with SIP
+ */
+export const mockMeeting = {
+  ID: 'mockMeeting1',
+  title: '5535@ucdemolab.com',
+  localAudio: {
+    stream: {},
+    permission: 'ALLOWED',
+  },
+  localVideo: {
+    stream: {},
+    permission: 'ALLOWED',
+  },
+  localShare: null,
+  remoteAudio: {},
+  remoteVideo: null,
+  remoteShare: null,
+  state: 'JOINED',
+};
+
+/**
  * Creates a new meeting SDK adapter instance based on a mock SDK.
  *
  * @returns {MeetingsSDKAdapter} A new instance of the meeting SDK adapter


### PR DESCRIPTION
- Add conditional check for meeting without `localShare.stream` which covers edge case when trying to leave a meeting and `localShare` is null, it throws an error.

```
Unable to leave from the meeting "SOME-ID" TypeError: Cannot read properties of null (reading 'stream')
    at Pm.removeMedia (webexSDKComponentAdapter.esm.js:15735)
    at Pm.leaveMeeting (webexSDKComponentAdapter.esm.js:15925)
    at wm.action (webexSDKComponentAdapter.esm.js:14860)
    at webex-components.umd.min.js:14
    at o.r.handleClick (index.js:49)
    at onClick (index.js:179)
```