### PR TITLE
fix(MeetingsSdkAdapter): set preview video stream in correct field when switching camera

### DIFF
--- a/src/MeetingsSDKAdapter.js
+++ b/src/MeetingsSDKAdapter.js
@@ -897,7 +897,7 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
         updates = {
           settings: {
             preview: {
-              stream,
+              video: stream,
             },
           },
           cameraID: deviceId,


### PR DESCRIPTION
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-285596