### PR TITLE
feat(MeetingsSdkAdapter): emit empty list from getAvailableDevices() if media not accessible

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -74,6 +74,7 @@
     "newline-after-var": "error",
     "newline-before-return": "error",
     "lines-around-directive": "error",
+    "operator-linebreak": "off",
     "no-useless-call": "error"
   },
   "overrides": [

--- a/scripts/index.html
+++ b/scripts/index.html
@@ -68,12 +68,23 @@
         <form id="devices">
           <fieldset>
             <legend>Media Devices</legend>
-            <label for="switch-camera">Choose preferred camera:</label>
-            <select id="switch-camera"></select>
-            <label for="switch-microphone">Choose preferred microphone:</label>
-            <select id="switch-microphone"></select>
-            <label for="switch-speaker">Choose preferred speaker:</label>
-            <select id="switch-speaker"></select>
+            <table>
+              <tr>
+                <td><label for="switch-camera">Camera:</label></td>
+                <td id="video-perm"></td>
+                <td><select id="switch-camera"></select></td>
+              </tr>
+              <tr>
+                <td><label for="switch-camera">Microphone:</label></td>
+                <td id="audio-perm"></td>
+                <td><select id="switch-microphone"></select></td>
+              </tr>
+              <tr>
+                <td><label for="switch-camera">Speaker:</label></td>
+                <td></td>
+                <td><select id="switch-speaker"></select></td>
+              </tr>
+            </table>
           </fieldset>
         </form>
         <form id="members">

--- a/src/MeetingsSDKAdapter.test.js
+++ b/src/MeetingsSDKAdapter.test.js
@@ -39,12 +39,12 @@ describe('Meetings SDK Adapter', () => {
 
   describe('getLocalMedia()', () => {
     test('returns local media in a proper shape', (done) => {
-      meetingsSDKAdapter.getLocalMedia(meetingID).pipe(last()).subscribe((dataDisplay) => {
-        expect(dataDisplay.localAudio.stream).toMatchMediaStream(mockSDKMediaStreams.localAudio);
-        expect(dataDisplay.localVideo.stream).toMatchMediaStream(mockSDKMediaStreams.localVideo);
+      meetingsSDKAdapter.getLocalMedia(meetingID).pipe(last()).subscribe((localMedia) => {
+        expect(localMedia.localAudio.stream).toMatchMediaStream(mockSDKMediaStreams.localAudio);
+        expect(localMedia.localVideo.stream).toMatchMediaStream(mockSDKMediaStreams.localVideo);
 
-        expect(dataDisplay.localAudio.permission).toBe('ALLOWED');
-        expect(dataDisplay.localVideo.permission).toBe('ALLOWED');
+        expect(localMedia.localAudio.permission).toBe('ALLOWED');
+        expect(localMedia.localVideo.permission).toBe('ALLOWED');
         done();
       });
     });
@@ -94,8 +94,7 @@ describe('Meetings SDK Adapter', () => {
             'MEETING',
             'meetingID',
             'getStream()',
-            ['Unable to retrieve local media stream',
-              {mediaDirection: {sendAudio: true}, audioVideo: undefined}],
+            'Unable to retrieve local media stream',
             sdkError.error,
           );
           done();

--- a/src/MeetingsSDKAdapter/controls/SwitchCameraControl.js
+++ b/src/MeetingsSDKAdapter/controls/SwitchCameraControl.js
@@ -1,7 +1,4 @@
-import {
-  defer,
-  Observable,
-} from 'rxjs';
+import {Observable} from 'rxjs';
 import {distinctUntilChanged, map, tap} from 'rxjs/operators';
 import logger from '../../logger';
 import MeetingControl from './MeetingControl';
@@ -34,11 +31,13 @@ export default class SwitchCameraControl extends MeetingControl {
    */
   display(meetingID) {
     logger.debug('MEETING', meetingID, 'SwitchCameraControl::display()', ['called with', {meetingID}]);
+
     const cameraID$ = this.adapter.getMeeting(meetingID).pipe(
       map((meeting) => meeting.cameraID),
       distinctUntilChanged(),
     );
-    const options$ = defer(() => this.adapter.getAvailableDevices(meetingID, 'videoinput')).pipe(
+
+    const options$ = this.adapter.getAvailableDevices(meetingID, 'videoinput').pipe(
       map((availableCameras) => availableCameras.map((camera) => ({
         value: camera.deviceId,
         label: camera.label,

--- a/src/MeetingsSDKAdapter/controls/SwitchCameraControl.test.js
+++ b/src/MeetingsSDKAdapter/controls/SwitchCameraControl.test.js
@@ -3,9 +3,12 @@ import {meetingID, createTestMeetingsSDKAdapter} from '../testHelper';
 
 describe('Switch Camera Control', () => {
   let meetingsSDKAdapter;
+  let meeting;
 
   beforeEach(() => {
     meetingsSDKAdapter = createTestMeetingsSDKAdapter();
+    meeting = meetingsSDKAdapter.meetings[meetingID];
+    meeting.localVideo.permission = 'ALLOWED';
   });
 
   afterEach(() => {

--- a/src/MeetingsSDKAdapter/controls/SwitchMicrophoneControl.js
+++ b/src/MeetingsSDKAdapter/controls/SwitchMicrophoneControl.js
@@ -1,7 +1,4 @@
-import {
-  defer,
-  Observable,
-} from 'rxjs';
+import {Observable} from 'rxjs';
 import {distinctUntilChanged, map, tap} from 'rxjs/operators';
 import logger from '../../logger';
 import MeetingControl from './MeetingControl';
@@ -35,12 +32,13 @@ export default class SwitchMicrophoneControl extends MeetingControl {
    */
   display(meetingID) {
     logger.debug('MEETING', meetingID, 'SwitchMicrophoneControl::display()', ['called with', {meetingID}]);
+
     const microphoneID$ = this.adapter.getMeeting(meetingID).pipe(
       map((meeting) => meeting.microphoneID),
       distinctUntilChanged(),
     );
 
-    const options$ = defer(() => this.adapter.getAvailableDevices(meetingID, 'audioinput')).pipe(
+    const options$ = this.adapter.getAvailableDevices(meetingID, 'audioinput').pipe(
       map((availableMicrophones) => availableMicrophones.map((microphone) => ({
         value: microphone.deviceId,
         label: microphone.label,

--- a/src/MeetingsSDKAdapter/controls/SwitchMicrophoneControl.test.js
+++ b/src/MeetingsSDKAdapter/controls/SwitchMicrophoneControl.test.js
@@ -3,9 +3,12 @@ import {meetingID, createTestMeetingsSDKAdapter} from '../testHelper';
 
 describe('Switch Microphone Control', () => {
   let meetingsSDKAdapter;
+  let meeting;
 
   beforeEach(() => {
     meetingsSDKAdapter = createTestMeetingsSDKAdapter();
+    meeting = meetingsSDKAdapter.meetings[meetingID];
+    meeting.localAudio.permission = 'ALLOWED';
   });
 
   afterEach(() => {

--- a/src/MeetingsSDKAdapter/controls/SwitchSpeakerControl.js
+++ b/src/MeetingsSDKAdapter/controls/SwitchSpeakerControl.js
@@ -1,7 +1,4 @@
-import {
-  defer,
-  Observable,
-} from 'rxjs';
+import {Observable} from 'rxjs';
 import {distinctUntilChanged, map, tap} from 'rxjs/operators';
 import logger from '../../logger';
 import MeetingControl from './MeetingControl';
@@ -34,11 +31,13 @@ export default class SwitchSpeakerControl extends MeetingControl {
    */
   display(meetingID) {
     logger.debug('MEETING', meetingID, 'SwitchSpeakerControl::display()', ['called with', {meetingID}]);
+
     const speakerID$ = this.adapter.getMeeting(meetingID).pipe(
       map((meeting) => meeting.speakerID),
       distinctUntilChanged(),
     );
-    const options$ = defer(() => this.adapter.getAvailableDevices(meetingID, 'audiooutput')).pipe(
+
+    const options$ = this.adapter.getAvailableDevices(meetingID, 'audiooutput').pipe(
       map((availableSpeakers) => availableSpeakers.map((speaker) => ({
         value: speaker.deviceId,
         label: speaker.label,

--- a/src/MeetingsSDKAdapter/controls/SwitchSpeakerControl.test.js
+++ b/src/MeetingsSDKAdapter/controls/SwitchSpeakerControl.test.js
@@ -3,9 +3,12 @@ import {meetingID, createTestMeetingsSDKAdapter} from '../testHelper';
 
 describe('Switch Speaker Control', () => {
   let meetingsSDKAdapter;
+  let meeting;
 
   beforeEach(() => {
     meetingsSDKAdapter = createTestMeetingsSDKAdapter();
+    meeting = meetingsSDKAdapter.meetings[meetingID];
+    meeting.localAudio.permission = 'ALLOWED';
   });
 
   afterEach(() => {


### PR DESCRIPTION
Refactored getAvailableDevices to return an observable dependent on the media stream permission status (eg: meeting.localVideo.permission). When the permission changes, a new list of devices is emitted. If the permission is not 'ALLOWED' (user did not allow or device disabled from operating system), an empty device list is emitted to prevent the device dropdowns in Settings to be populated with unusable devices. With zero options, those dropdowns will be disabled.

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-290120