### PR TITLE
fix(logger): prevent logger js errors by handling logging objects with circular references

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,8 +1,4 @@
-import logger from './src/logger';
 import mockDevices from './src/mockDevices';
-
-// set the error level
-logger.setLevel('error');
 
 // Mock Web Media APIs
 

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,4 +1,5 @@
 import {createLogger, format, transports} from 'winston';
+import {safeJsonStringify} from './utils';
 
 const logFormat = format.printf(({
   timestamp, level, resourceType, resourceID, action, message, error,
@@ -8,7 +9,7 @@ const logFormat = format.printf(({
   if (Array.isArray(message)) {
     msgString = message.map((item) => (
       (typeof item === 'string' && item)
-      || JSON.stringify(item, (key, value) => (
+      || safeJsonStringify(item, (key, value) => (
         (value instanceof MediaStream && `MediaStream([${value.getTracks().map((track) => track.kind)}])`)
         || value
       ), 2)


### PR DESCRIPTION
There are some logger-generated errors when logging some memberships objects received from the SDK that I would like to prevent.