### PR TITLE
feat(cache): add cache module

### DIFF
--- a/src/WebexSDKAdapter.js
+++ b/src/WebexSDKAdapter.js
@@ -6,6 +6,7 @@ import MeetingsSDKAdapter from './MeetingsSDKAdapter';
 import MembershipsSDKAdapter from './MembershipsSDKAdapter';
 import OrganizationsSDKAdapter from './OrganizationsSDKAdapter';
 import logger from './logger';
+import cache from './cache';
 import {name, version} from '../package.json';
 
 const LOG_ARGS = ['SDK', `${name}-${version}`];
@@ -30,6 +31,7 @@ export default class WebexSDKAdapter extends WebexAdapter {
     this.membershipsAdapter = new MembershipsSDKAdapter(sdk);
     this.organizationsAdapter = new OrganizationsSDKAdapter(sdk);
     this.sdk = sdk;
+    this.cache = cache;
   }
 
   /**

--- a/src/cache.js
+++ b/src/cache.js
@@ -1,0 +1,124 @@
+import logger from './logger';
+
+/**
+ * @description A module to handle caching data from Webex SDK.
+ * @see {@link https://www.youtube.com/watch?v=ZrtSOTGNqA8}
+ *
+ * @module CacheMeOutside No-pun intented
+ * @returns {CacheMeOutside}
+ */
+class CacheMeOutside {
+  constructor() {
+    this.store = new Map();
+    logger.debug('CacheMeOutside', null, 'init()', []);
+  }
+
+  /**
+   * Cache data or update and existing record.
+   *
+   * @param {string} key Unique key identifying the cache
+   * @param {object} value Cached value
+   * @returns {CacheMeOutside} Returns instance of caching module
+   */
+  set(key, value) {
+    logger.debug('CacheMeOutside', null, 'set()', [key]);
+
+    return this.store.set(key, value);
+  }
+
+  /**
+   * Get cached value. Returns cached value (or undefined)
+   *
+   * @param {string} key Key identifying the cache
+   * @returns {object} Cached value
+   */
+  get(key) {
+    logger.debug('CacheMeOutside', null, 'get()', [key]);
+
+    return this.store.get(key);
+  }
+
+  /**
+   * Check for cached key.
+   *
+   * @param {string} key Key identifying the cache
+   * @returns {boolean} Returns true/false if key exists
+   */
+  has(key) {
+    return this.store.has(key);
+  }
+
+  /**
+   * Removes key from cache.
+   *
+   * @param {string} key Key identifying the cache
+   * @returns {boolean} Returns true/false if key removed
+   */
+  remove(key) {
+    return this.store.delete(key);
+  }
+
+  /**
+   * Returns array of all values in cache
+   *
+   * @returns {Array} Array of values
+   */
+  values() {
+    return this.store.values();
+  }
+
+  /**
+   * Returns the number of keys in the cache
+   *
+   * @returns {number} Size of cache
+   */
+  size() {
+    return this.store.size;
+  }
+
+  /**
+   * Returns array of all keys in cache
+   *
+   * @returns {Array} Array of keys
+   */
+  keys() {
+    return this.store.keys();
+  }
+
+  /**
+   * I take an array of SDK conversations and cache them.
+   *
+   * @param {Array} conversations Array of sdk server rooms
+   */
+  cacheConversations(conversations) {
+    logger.debug('CacheMeOutside', 'cacheConversations()', conversations.length, []);
+
+    conversations.map((o) => this.set(o.id, o));
+  }
+
+  /**
+   * I take an array of server activities and cache them.
+   *
+   * @param {Array} activities Array of sdk server activities
+   */
+  cachActivities(activities) {
+    logger.debug('CacheMeOutside', 'cachActivities()', activities.length, []);
+
+    activities.map((o) => this.set(o.id, o));
+  }
+
+  /**
+   * I take an array of SDK activities and convert them into adapter activities.
+   *
+   * @param {Array} sdkActivities Array of sdk server activities
+   */
+  cachSDKActivities(sdkActivities) {
+    logger.debug('CacheMeOutside', 'cachSDKActivities()', sdkActivities.length, []);
+
+    sdkActivities.map((o) => this.set(o.id, o));
+  }
+}
+
+const singleton = new CacheMeOutside();
+
+export default singleton;

--- a/src/cache.test.js
+++ b/src/cache.test.js
@@ -1,0 +1,46 @@
+import cache from './cache';
+import {mockSDKRoom} from './mockSdk';
+import mockActivities from './mockActivities';
+
+describe('CacheMeOutside', () => {
+  test('should return single cache instance', () => {
+    expect(cache).toBeTruthy();
+  });
+  test('set - should set value in cache', () => {
+    expect(cache.set('name', 'some-value')).toBeTruthy();
+  });
+  test('get - should get value in cache by key', () => {
+    expect(cache.get('name')).toEqual('some-value');
+  });
+  test('size - returns the size of the cache', () => {
+    expect(cache.size()).toEqual(1);
+  });
+  test('values - returns all the values in cache', () => {
+    expect([...cache.values()][0]).toEqual('some-value');
+  });
+  test('keys - returns all the keys in cache', () => {
+    expect([...cache.keys()][0]).toEqual('name');
+  });
+  test('has - should return true if key in cache', () => {
+    expect(cache.has('name')).toBeTruthy();
+  });
+  test('remove - should remove in cache by key', () => {
+    expect(cache.remove('name')).toBeTruthy();
+  });
+  test('has - should return false if key not in cache', () => {
+    expect(cache.has('name')).toBeFalsy();
+  });
+
+  describe('cachActivities', () => {
+    test('should set each activity in cache', () => {
+      cache.cachActivities(mockActivities);
+      expect(cache.get(mockActivities[0].id)).toBeTruthy();
+    });
+  });
+  describe('cacheConversations', () => {
+    test('should set each convo in cache', () => {
+      cache.cacheConversations([mockSDKRoom]);
+      expect(cache.get(mockSDKRoom.id)).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
- Added `cache` module to handle caching `activities` and `rooms`
- Purpose of this is to reduce calls to server for `getActivity` method, if `getPastActivities` method caches the returned activities, then when `useActivity` hook is ran cache should lookup and return `activity`.