### PR TITLE
fix(meeting): fetching captcha details within meeting object

### DIFF
--- a/src/MeetingsSDKAdapter.js
+++ b/src/MeetingsSDKAdapter.js
@@ -652,7 +652,7 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
               }),
             }));
         } else {
-          logger.info('MEETING', ID, 'joinMeeting()', 'Password succesfully verified');
+          logger.info('MEETING', ID, 'joinMeeting()', 'Password successfully verified');
         }
       }
       sdkMeeting.meetingFiniteStateMachine.reset();
@@ -1426,9 +1426,21 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
     await this.updateMeeting(ID, async () => ({invalidHostKey: false}));
   }
 
+  /**
+   * Refreshes the captcha code.
+   *
+   * @async
+   * @param {string} ID  Id of the meeting
+   */
   async refreshCaptcha(ID) {
+    logger.debug('MEETING', ID, 'refreshCaptcha()', ['called with', {ID}]);
     const sdkMeeting = this.fetchMeeting(ID);
 
     await sdkMeeting.refreshCaptcha();
+    this.updateMeeting(ID, () => (
+      {
+        requiredCaptcha: sdkMeeting.requiredCaptcha,
+      }
+    ));
   }
 }

--- a/src/MeetingsSDKAdapter.js
+++ b/src/MeetingsSDKAdapter.js
@@ -635,7 +635,8 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
       const sdkMeeting = this.fetchMeeting(ID);
 
       if (sdkMeeting.passwordStatus === 'REQUIRED') {
-        const res = await sdkMeeting.verifyPassword(options.hostKey || options.password, options.captcha);
+        const res = await sdkMeeting
+          .verifyPassword(options.hostKey || options.password, options.captcha);
 
         if (!res.isPasswordValid) {
           this.updateMeeting(ID, () => (
@@ -1372,6 +1373,7 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
     deepMerge(meeting, updates);
 
     logger.debug('MEETING', ID, 'updateMeeting()', ['meeting updated with', EVENT_MEETING_UPDATED, 'event', 'meeting object', {meeting}]);
+
     sdkMeeting.emit(EVENT_MEETING_UPDATED, meeting);
   }
 
@@ -1436,8 +1438,8 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
     logger.debug('MEETING', ID, 'refreshCaptcha()', ['called with', {ID}]);
     const sdkMeeting = this.fetchMeeting(ID);
 
-    await sdkMeeting.refreshCaptcha();
-    this.updateMeeting(ID, () => (
+    sdkMeeting.refreshCaptcha();
+    await this.updateMeeting(ID, () => (
       {
         requiredCaptcha: sdkMeeting.requiredCaptcha,
       }

--- a/src/MeetingsSDKAdapter.js
+++ b/src/MeetingsSDKAdapter.js
@@ -544,7 +544,10 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
    */
   createMeeting(destination) {
     const newMeeting$ = from(this.datasource.meetings.create(destination)).pipe(
-      map(({id, meetingInfo: {meetingName}, passwordStatus}) => ({
+      tap((meeting) => {
+        console.log('pkesari_meeting object: ', meeting);
+      }),
+      map(({id, meetingInfo: {meetingName}, passwordStatus}, requiredCaptcha) => ({
         ID: id,
         title: meetingName,
         localAudio: {
@@ -559,6 +562,7 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
           stream: null,
         },
         passwordRequired: passwordStatus === 'REQUIRED',
+        requiredCaptcha,
         remoteAudio: null,
         remoteVideo: null,
         remoteShare: null,
@@ -1405,5 +1409,11 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
    */
   async clearInvalidHostKeyFlag(ID) {
     await this.updateMeeting(ID, async () => ({invalidHostKey: false}));
+  }
+
+  async refreshCaptcha(ID) {
+    const sdkMeeting = this.fetchMeeting(ID);
+
+    await sdkMeeting.refreshCaptcha();
   }
 }

--- a/src/MeetingsSDKAdapter.js
+++ b/src/MeetingsSDKAdapter.js
@@ -635,7 +635,7 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
       const sdkMeeting = this.fetchMeeting(ID);
 
       if (sdkMeeting.passwordStatus === 'REQUIRED') {
-        const res = await sdkMeeting.verifyPassword(options.hostKey || options.password);
+        const res = await sdkMeeting.verifyPassword(options.hostKey || options.password, options.captcha);
 
         if (!res.isPasswordValid) {
           this.updateMeeting(ID, () => (

--- a/src/MeetingsSDKAdapter.test.js
+++ b/src/MeetingsSDKAdapter.test.js
@@ -1087,4 +1087,114 @@ describe('Meetings SDK Adapter', () => {
       expect(mockSDKMeeting.emit.mock.calls[0][1]).toMatchObject({invalidHostKey: false});
     });
   });
+
+  describe('refreshCaptcha()', () => {
+    const mockCaptcha = {
+      captchaId: 'Captcha_c57280d4-6baf-4a27-87e9-290757754bb6',
+      verificationImageURL: 'https://cisco.webex.com/captchaservice/v1/captchas/Captcha_c57280d4-6baf-4a27-87e9-290757754bb6/verificationCodeImage',
+      refreshURL: 'https://cisco.webex.com/captchaservice/v1/captchas/refresh?siteurl=cisco&captchaID=Captcha_c57280d4-6baf-4a27-87e9-290757754bb6',
+      verificationAudioURL: 'https://cisco.webex.com/captchaservice/v1/captchas/Captcha_c57280d4-6baf-4a27-87e9-290757754bb6/verificationCodeAudio',
+    };
+
+    it('refreshes the captcha', async () => {
+      meetingsSDKAdapter.meetings[meetingID].requiredCaptcha = {
+        captchaId: 'Captcha_b40798d4-6baf-4a27-bf77-2907577524d6',
+        verificationImageURL: 'https://cisco.webex.com/captchaservice/v1/captchas/Captcha_b40798d4-6baf-4a27-bf77-2907577524d6/verificationCodeImage',
+        refreshURL: 'https://cisco.webex.com/captchaservice/v1/captchas/refresh?siteurl=cisco&captchaID=Captcha_b40798d4-6baf-4a27-bf77-2907577524d6',
+        verificationAudioURL: 'https://cisco.webex.com/captchaservice/v1/captchas/Captcha_b40798d4-6baf-4a27-bf77-2907577524d6/verificationCodeAudio',
+      };
+
+      mockSDKMeeting.requiredCaptcha = mockCaptcha;
+
+      await meetingsSDKAdapter.refreshCaptcha(meetingID);
+
+      expect(mockSDKMeeting.refreshCaptcha).toHaveBeenCalledWith();
+      expect(mockSDKMeeting.emit).toHaveBeenCalledTimes(1);
+      expect(mockSDKMeeting.emit.mock.calls[0][0]).toBe('adapter:meeting:updated');
+      expect(mockSDKMeeting.emit.mock.calls[0][1]).toMatchObject({requiredCaptcha: mockCaptcha});
+    });
+  });
+
+  describe('joinMeeting()', () => {
+    const verifyPasswordRes1 = {
+      failureReason: 'WRONG_PASSWORD',
+      isPasswordValid: false,
+      requiredCaptcha: {
+        captchaId: 'Captcha_c3c3009f-c844-4305-b1c4-6aed2a251247',
+        refreshURL: 'https://cisco.webex.com/captchaservice/v1/captchas/refresh?siteurl=cisco&captchaID=Captcha_c3c3009f-c844-4305-b1c4-6aed2a251247',
+        verificationAudioURL: 'https://cisco.webex.com/captchaservice/v1/captchas/Captcha_c3c3009f-c844-4305-b1c4-6aed2a251247/verificationCodeAudio',
+        verificationImageURL: 'https://cisco.webex.com/captchaservice/v1/captchas/Captcha_c3c3009f-c844-4305-b1c4-6aed2a251247/verificationCodeImage',
+      },
+    };
+
+    const mockResponse1 = {
+      failureReason: 'WRONG_PASSWORD',
+      invalidPassword: true,
+      requiredCaptcha: {
+        captchaId: 'Captcha_c3c3009f-c844-4305-b1c4-6aed2a251247',
+        refreshURL: 'https://cisco.webex.com/captchaservice/v1/captchas/refresh?siteurl=cisco&captchaID=Captcha_c3c3009f-c844-4305-b1c4-6aed2a251247',
+        verificationAudioURL: 'https://cisco.webex.com/captchaservice/v1/captchas/Captcha_c3c3009f-c844-4305-b1c4-6aed2a251247/verificationCodeAudio',
+        verificationImageURL: 'https://cisco.webex.com/captchaservice/v1/captchas/Captcha_c3c3009f-c844-4305-b1c4-6aed2a251247/verificationCodeImage',
+      },
+    };
+
+    const verifyPasswordRes2 = {
+      failureReason: 'WRONG_CAPTCHA',
+      isPasswordValid: false,
+      requiredCaptcha: {
+        captchaId: 'Captcha_e34a56d8-c75e-4424-9a34-b1dd28badd68',
+        refreshURL: 'https://cisco.webex.com/captchaservice/v1/captchas/refresh?siteurl=cisco&captchaID=Captcha_e34a56d8-c75e-4424-9a34-b1dd28badd68',
+        verificationAudioURL: 'https://cisco.webex.com/captchaservice/v1/captchas/Captcha_e34a56d8-c75e-4424-9a34-b1dd28badd68/verificationCodeAudio',
+        verificationImageURL: 'https://cisco.webex.com/captchaservice/v1/captchas/Captcha_e34a56d8-c75e-4424-9a34-b1dd28badd68/verificationCodeImage',
+      },
+    };
+
+    const mockResponse2 = {
+      failureReason: 'WRONG_CAPTCHA',
+      invalidPassword: true,
+      requiredCaptcha: {
+        captchaId: 'Captcha_e34a56d8-c75e-4424-9a34-b1dd28badd68',
+        refreshURL: 'https://cisco.webex.com/captchaservice/v1/captchas/refresh?siteurl=cisco&captchaID=Captcha_e34a56d8-c75e-4424-9a34-b1dd28badd68',
+        verificationAudioURL: 'https://cisco.webex.com/captchaservice/v1/captchas/Captcha_e34a56d8-c75e-4424-9a34-b1dd28badd68/verificationCodeAudio',
+        verificationImageURL: 'https://cisco.webex.com/captchaservice/v1/captchas/Captcha_e34a56d8-c75e-4424-9a34-b1dd28badd68/verificationCodeImage',
+      },
+    };
+
+    it('joinMeeting with correct password with no captcha needed', async () => {
+      mockSDKMeeting.verifyPassword = jest.fn(() => Promise.resolve({
+        failureReason: 'NONE',
+        isPasswordValid: true,
+        requiredCaptcha: null,
+      }));
+      await meetingsSDKAdapter.joinMeeting(meetingID, {password: 'BJzbHDKd347'});
+
+      expect(mockSDKMeeting.verifyPassword).toHaveBeenCalledWith('BJzbHDKd347', undefined);
+      expect(mockSDKMeeting.emit).not.toHaveBeenCalled();
+      expect(mockSDKMeeting.join).toHaveBeenCalledTimes(1);
+    });
+
+    it('joinMeeting with incorrect password multiple times and receiving captcha code to be entered', async () => {
+      mockSDKMeeting.verifyPassword = jest.fn(() => Promise.resolve(verifyPasswordRes1));
+      mockSDKMeeting.requiredCaptcha = verifyPasswordRes1.requiredCaptcha;
+
+      await meetingsSDKAdapter.joinMeeting(meetingID, {password: 'fahdkwlr'});
+
+      expect(mockSDKMeeting.verifyPassword).toHaveBeenCalledWith('fahdkwlr', undefined);
+      expect(mockSDKMeeting.emit).toHaveBeenCalledTimes(1);
+      expect(mockSDKMeeting.emit.mock.calls[0][0]).toBe('adapter:meeting:updated');
+      expect(mockSDKMeeting.emit.mock.calls[0][1]).toMatchObject(mockResponse1);
+    });
+
+    it('joinMeeting with correct password and incorrect captcha', async () => {
+      mockSDKMeeting.verifyPassword = jest.fn(() => Promise.resolve(verifyPasswordRes2));
+      mockSDKMeeting.requiredCaptcha = verifyPasswordRes2.requiredCaptcha;
+
+      await meetingsSDKAdapter.joinMeeting(meetingID, {password: 'BJzbHDKd347', captcha: 'pfucip'});
+
+      expect(mockSDKMeeting.verifyPassword).toHaveBeenCalledWith('BJzbHDKd347', 'pfucip');
+      expect(mockSDKMeeting.emit).toHaveBeenCalledTimes(1);
+      expect(mockSDKMeeting.emit.mock.calls[0][0]).toBe('adapter:meeting:updated');
+      expect(mockSDKMeeting.emit.mock.calls[0][1]).toMatchObject(mockResponse2);
+    });
+  });
 });

--- a/src/MeetingsSDKAdapter/testHelper.js
+++ b/src/MeetingsSDKAdapter/testHelper.js
@@ -25,6 +25,7 @@ export function createTestMeetingsSDKAdapter() {
     remoteAudio: null,
     remoteVideo: null,
     remoteShare: null,
+    requiredCaptcha: {},
     showRoster: null,
     settings: {
       visible: false,

--- a/src/mockSdk.js
+++ b/src/mockSdk.js
@@ -83,6 +83,9 @@ export const createMockSDKMeeting = () => ({
   meetingInfo: {
     isWebexScheduled: true,
   },
+  meetingFiniteStateMachine: {
+    reset: jest.fn(),
+  },
   members: {
     membersCollection: {
       members: {
@@ -174,6 +177,7 @@ export const createMockSDKMeeting = () => ({
   canUpdateMedia: jest.fn(() => true),
   updateShare: jest.fn(() => Promise.resolve()),
   changeVideoLayout: jest.fn(() => Promise.resolve()),
+  refreshCaptcha: jest.fn(),
 });
 
 export const mockSDKMembership = {


### PR DESCRIPTION
Storing the response for verifyPassword() and fetch details like invalidPassword, failureReason and requiredCaptcha and update the meeting object with these details.
Updated verifyPassword() function to accept captcha as a parameter.
Added a new function to refresh the captcha when needed

JIRA: https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-521834 

Tests Performed:

1. Entered the wrong password several times. Captcha inbox appeared to enter the captcha.
2. Entered incorrect password with the valid captcha code.
3. Entered the correct password with the wrong captcha code.
4. Entered the correct password with a valid captcha code.

Meeting Widget Testing
https://github.com/webex/sdk-component-adapter/assets/65543166/8b6b8ee4-7676-48b2-a122-32a487a7b1d1

Logs
[Widgets_Testing_logs.log](https://github.com/user-attachments/files/16026111/Widgets_Testing_logs.log)

