### PR TITLE
fix(package): remove engine requirement from package as this breaks downstream app upgrades

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@webex/sdk-component-adapter",
   "version": "1.112.7",
-  "engines": {
-    "node": ">=20.13.1"
-  },
   "main": "dist/webexSDKComponentAdapter.umd.js",
   "module": "dist/webexSDKComponentAdapter.esm.js",
   "scripts": {


### PR DESCRIPTION
This PR is to remove the `engines` keyword from the sdk-component-adapter package as it's breaking installs on downstream applications like Instant Connect even though they are not directly dependent on this package.
```
error @webex/sdk-component-adapter@1.112.7: The engine "node" is incompatible with this module. Expected version ">=20.13.1". Got "16.20.2"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```