### PR TITLE
fix(MeetingsSdkAdapter): handle joinMeeting with empty password

### DIFF
--- a/src/MeetingsSDKAdapter.js
+++ b/src/MeetingsSDKAdapter.js
@@ -635,6 +635,14 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
       const sdkMeeting = this.fetchMeeting(ID);
 
       if (sdkMeeting.passwordStatus === 'REQUIRED') {
+        if (!(options.password || options.hostKey)) {
+          this.updateMeeting(ID, () => (
+            {
+              passwordRequired: true,
+            }));
+
+          return;
+        }
         const res = await sdkMeeting
           .verifyPassword(options.hostKey || options.password, options.captcha);
 

--- a/src/MeetingsSDKAdapter.test.js
+++ b/src/MeetingsSDKAdapter.test.js
@@ -1196,5 +1196,14 @@ describe('Meetings SDK Adapter', () => {
       expect(mockSDKMeeting.emit.mock.calls[0][0]).toBe('adapter:meeting:updated');
       expect(mockSDKMeeting.emit.mock.calls[0][1]).toMatchObject(mockResponse2);
     });
+
+    it('joinMeeting with empty password', async () => {
+      mockSDKMeeting.verifyPassword = jest.fn();
+      await meetingsSDKAdapter.joinMeeting(meetingID, {password: ''});
+
+      expect(mockSDKMeeting.verifyPassword).not.toHaveBeenCalled();
+      expect(mockSDKMeeting.emit).toHaveBeenCalledTimes(1);
+      expect(mockSDKMeeting.join).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
Issue: Not showing password popup when click join meeting after dismissing initial popup.
Fix: added condition to check passwordRequired and empty options to updateMeeting with passwordRequired true

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-557507 

![Screenshot 2024-09-30 at 8 31 25 PM](https://github.com/user-attachments/assets/10ad2373-1a5c-4e48-9792-4cd8c2c93857)
![Screenshot 2024-09-30 at 8 31 32 PM](https://github.com/user-attachments/assets/12a6f2be-cee4-4802-9032-3ac71427c38e)

