### PR TITLE
fix: update meeting name after fetch meetinginfo

### DIFF
--- a/src/MeetingsSDKAdapter.js
+++ b/src/MeetingsSDKAdapter.js
@@ -595,9 +595,11 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
       )),
       tap((meeting) => {
         const sdkMeeting = this.fetchMeeting(meeting.ID);
+        const updatedTitle = sdkMeeting.meetingInfo.topic || meeting.title;
+        const updatedMeeting = {...meeting, title: updatedTitle};
 
-        this.meetings[meeting.ID] = meeting;
-        sdkMeeting.emit(EVENT_MEETING_UPDATED, meeting);
+        this.meetings[meeting.ID] = updatedMeeting;
+        sdkMeeting.emit(EVENT_MEETING_UPDATED, updatedMeeting);
       }),
       catchError((err) => {
         logger.error('MEETING', destination, 'createMeeting()', `Unable to create a meeting with "${destination}"`, err);

--- a/src/MeetingsSDKAdapter.js
+++ b/src/MeetingsSDKAdapter.js
@@ -637,13 +637,6 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
     try {
       const sdkMeeting = this.fetchMeeting(ID);
 
-      // eslint-disable-next-line no-console
-      console.log('ravi joinMeeting sdkMeeting ', sdkMeeting);
-
-      if (sdkMeeting.meetingInfo.topic) {
-        this.updateMeeting(ID, () => ({title: sdkMeeting.meetingInfo.topic}));
-      }
-
       if (sdkMeeting.passwordStatus === 'REQUIRED') {
         if (!(options.password || options.hostKey)) {
           this.updateMeeting(ID, () => (

--- a/src/MeetingsSDKAdapter.test.js
+++ b/src/MeetingsSDKAdapter.test.js
@@ -450,6 +450,40 @@ describe('Meetings SDK Adapter', () => {
       });
     });
 
+    it('should emit EVENT_MEETING_UPDATED with the updated title from sdkMeeting.meetingInfo.topic', (done) => {
+      // Mock implementations
+      meetingsSDKAdapter.fetchMeetingTitle = jest.fn(() => Promise.resolve('my meeting'));
+      meetingsSDKAdapter.getLocalMedia = jest.fn(() => rxjs.of({
+        localAudio: {
+          stream: mockSDKMediaStreams.localAudio,
+          permission: 'ALLOWED',
+        },
+        localVideo: {
+          stream: mockSDKMediaStreams.localVideo,
+          permission: 'ALLOWED',
+        },
+      }));
+
+      // Mock fetchMeeting to return an object containing meetingInfo.topic and an emit function
+      const mockEmit = jest.fn();
+
+      meetingsSDKAdapter.fetchMeeting = jest.fn(() => ({
+        meetingInfo: {
+          topic: 'Updated Meeting Title',
+        },
+        emit: mockEmit,
+      }));
+
+      meetingsSDKAdapter.createMeeting(target).pipe(last()).subscribe(() => {
+        // Ensure the emit function was called with the updated meeting
+        expect(mockEmit).toHaveBeenCalledWith('adapter:meeting:updated', expect.objectContaining({
+          title: 'Updated Meeting Title',
+        }));
+
+        done();
+      });
+    });
+
     it('throws error on failed meeting push request', (done) => {
       const wrongTarget = 'wrongTarget';
       const errorMessage = `Unable to create a meeting "${wrongTarget}"`;

--- a/src/MeetingsSDKAdapter.test.js
+++ b/src/MeetingsSDKAdapter.test.js
@@ -452,7 +452,6 @@ describe('Meetings SDK Adapter', () => {
 
     it('should emit EVENT_MEETING_UPDATED with the updated title from sdkMeeting.meetingInfo.topic', (done) => {
       // Mock implementations
-      meetingsSDKAdapter.fetchMeetingTitle = jest.fn(() => Promise.resolve('my meeting'));
       meetingsSDKAdapter.getLocalMedia = jest.fn(() => rxjs.of({
         localAudio: {
           stream: mockSDKMediaStreams.localAudio,


### PR DESCRIPTION
Issue: Meeting name not showing in meeting widget instead it shows sip address.
Fix: added update title code in fetchMeetingInfo.topic

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-566707

![Screenshot 2024-10-09 at 7 26 00 PM](https://github.com/user-attachments/assets/b2ff7169-1462-48b3-b8ff-700626126896)
![Screenshot 2024-10-09 at 7 26 13 PM](https://github.com/user-attachments/assets/4f85ff87-5506-4715-87c4-230721e763ae)
![Screenshot 2024-10-09 at 7 27 58 PM](https://github.com/u
<img width="486" alt="Screenshot 2024-10-10 at 4 02 11 PM" src="https://github.com/user-attachments/assets/d16aa5eb-4e1e-441c-a2fb-7938678c5856">
<img width="480" alt="Screenshot 2024-10-10 at 4 03 09 PM" src="https://github.com/user-attachments/assets/bd0a99f4-03f3-413a-98e7-553cd9c546a2">
<img width="494" alt="Screenshot 2024-10-10 at 4 03 37 PM" src="https://github.com/user-attachments/assets/c57c75f3-b3fa-42d1-abe3-051699eb3b14">
ser-attachments/assets/8e1c0bb1-686a-41a0-9bb6-da2a5398a4c7)

