### PR TITLE
fix(MembershipsSdkAdapter):added name property to member mapping in getmembers function

### DIFF
--- a/src/MembershipsSDKAdapter.js
+++ b/src/MembershipsSDKAdapter.js
@@ -115,6 +115,7 @@ function getMembers(sdkMembers, meeting) {
     sharing: member.isContentSharing,
     host: !!meeting.meetingInfo.isWebexScheduled && member.isModerator,
     guest: member.isGuest,
+    name:member.name,
   }));
 }
 

--- a/src/MembershipsSDKAdapter.js
+++ b/src/MembershipsSDKAdapter.js
@@ -115,7 +115,7 @@ function getMembers(sdkMembers, meeting) {
     sharing: member.isContentSharing,
     host: !!meeting.meetingInfo.isWebexScheduled && member.isModerator,
     guest: member.isGuest,
-    name:member.name,
+    name: member.name,
   }));
 }
 

--- a/src/MembershipsSDKAdapter.test.js
+++ b/src/MembershipsSDKAdapter.test.js
@@ -44,6 +44,7 @@ describe('Memberships SDK Adapter', () => {
                 sharing: false,
                 host: false,
                 guest: false,
+                name: 'Barbara German',
               },
               {
                 ID: 'mutedPerson',
@@ -53,6 +54,7 @@ describe('Memberships SDK Adapter', () => {
                 sharing: true,
                 host: true,
                 guest: true,
+                name: 'Brenda Song',
               },
               {
                 ID: 'notJoinedPerson',
@@ -62,6 +64,7 @@ describe('Memberships SDK Adapter', () => {
                 sharing: false,
                 host: false,
                 guest: true,
+                name: 'Giacomo Edwards',
               },
               {
                 ID: 'device',
@@ -71,6 +74,7 @@ describe('Memberships SDK Adapter', () => {
                 sharing: false,
                 host: false,
                 guest: false,
+                name: undefined,
               },
             ]);
             done();


### PR DESCRIPTION
## This pull request addresses 
This PR enhances the getMembers function by including the `name` property in the returned member objects. By adding the `name: member.name`, each member object now contains the participant's display name in a local sample app of widgets, improving the comprehensiveness of the member data. If the user wanted to pass the `name` according to there wish that will be appear on widgets sample app (or) the system default name will be displayed

please do refer to the screenrecording

https://github.com/user-attachments/assets/5cc7464e-bbc4-470c-a44b-f61e96e93e79




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced member information by including the member's name in the list returned by the membership function.
  
- **Bug Fixes**
	- Improved error handling for invalid meeting IDs and SDK failures in adding members.

- **Tests**
	- Expanded test coverage for member attributes and refined error handling in the membership-related tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->