### PR TITLE
fix(MembershipsSdkAdapter): add name for members in getMembers method

### DIFF
--- a/src/MembershipsSDKAdapter.test.js
+++ b/src/MembershipsSDKAdapter.test.js
@@ -44,7 +44,7 @@ describe('Memberships SDK Adapter', () => {
                 sharing: false,
                 host: false,
                 guest: false,
-                name: 'Barbara German', //test names against mock sdk
+                name: 'Barbara German', // test names against mock sdk
               },
               {
                 ID: 'mutedPerson',

--- a/src/MembershipsSDKAdapter.test.js
+++ b/src/MembershipsSDKAdapter.test.js
@@ -44,7 +44,7 @@ describe('Memberships SDK Adapter', () => {
                 sharing: false,
                 host: false,
                 guest: false,
-                name: 'John Doe',
+                name: 'Barbara German', //test names against mock sdk
               },
               {
                 ID: 'mutedPerson',

--- a/src/MembershipsSDKAdapter.test.js
+++ b/src/MembershipsSDKAdapter.test.js
@@ -44,7 +44,7 @@ describe('Memberships SDK Adapter', () => {
                 sharing: false,
                 host: false,
                 guest: false,
-                name: 'Barbara German',
+                name: 'John Doe',
               },
               {
                 ID: 'mutedPerson',


### PR DESCRIPTION
## Closes [SPARK-552246](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-552246)

## In this PR
The PR title did not have a space after the colon symbol leading to publish failure. Therefore with a minor change in the test file, this PR will have the right title to get a new version published. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Updated test cases for `getMembersFromDestination()` to ensure accurate validation of expected member names.
	- Enhanced `addRoomMember()` test to include success and error scenarios, validating the emitted membership objects effectively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->