### PR TITLE
feat(meeting): enable input of password and name while initializing widget

### DIFF
--- a/src/MeetingsSDKAdapter/controls/AudioControl.js
+++ b/src/MeetingsSDKAdapter/controls/AudioControl.js
@@ -16,9 +16,9 @@ export default class AudioControl extends MeetingControl {
    * Calls the adapter handleLocalAudio() method
    *
    * @private
-   * @param {string} meetingID  ID of the meeting to mute audio
+   * @param {meetingID}  ID of the meeting to mute audio
    */
-  action(meetingID) {
+  action({meetingID}) {
     logger.debug('MEETING', meetingID, 'AudioControl::action()', ['called with', {meetingID}]);
 
     return this.adapter.handleLocalAudio(meetingID);

--- a/src/MeetingsSDKAdapter/controls/AudioControl.test.js
+++ b/src/MeetingsSDKAdapter/controls/AudioControl.test.js
@@ -41,7 +41,7 @@ describe('Audio Control', () => {
   describe('action()', () => {
     it('calls handleLocalAudio() SDK adapter method', async () => {
       meetingsSDKAdapter.handleLocalAudio = jest.fn();
-      await meetingsSDKAdapter.meetingControls['mute-audio'].action(meetingID);
+      await meetingsSDKAdapter.meetingControls['mute-audio'].action({meetingID});
       expect(meetingsSDKAdapter.handleLocalAudio).toHaveBeenCalledTimes(1);
       expect(meetingsSDKAdapter.handleLocalAudio).toHaveBeenCalledWith(meetingID);
     });

--- a/src/MeetingsSDKAdapter/controls/ExitControl.js
+++ b/src/MeetingsSDKAdapter/controls/ExitControl.js
@@ -16,7 +16,7 @@ export default class ExitControl extends MeetingControl {
    *
    * @param {string} meetingID  Id of the meeting to leave from
    */
-  async action(meetingID) {
+  async action({meetingID}) {
     logger.debug('MEETING', meetingID, 'ExitControl::action()', ['called with', {meetingID}]);
 
     await this.adapter.leaveMeeting(meetingID);

--- a/src/MeetingsSDKAdapter/controls/ExitControl.test.js
+++ b/src/MeetingsSDKAdapter/controls/ExitControl.test.js
@@ -29,7 +29,7 @@ describe('Exit Control', () => {
   describe('action()', () => {
     it('calls leaveMeeting() SDK adapter method', async () => {
       meetingsSDKAdapter.leaveMeeting = jest.fn();
-      await meetingsSDKAdapter.meetingControls['leave-meeting'].action(meetingID);
+      await meetingsSDKAdapter.meetingControls['leave-meeting'].action({meetingID});
       expect(meetingsSDKAdapter.leaveMeeting).toHaveBeenCalledWith(meetingID);
     });
   });

--- a/src/MeetingsSDKAdapter/controls/JoinControl.js
+++ b/src/MeetingsSDKAdapter/controls/JoinControl.js
@@ -15,12 +15,15 @@ export default class JoinControl extends MeetingControl {
   /**
    * Calls the adapter joinMeeting method.
    *
-   * @param {string} meetingID  Id of the meeting to join
+   * @param {meetingID, meetingPasswordOrPin}
    */
-  async action(meetingID) {
+  async action({meetingID, meetingPasswordOrPin, participantName}) {
     logger.debug('MEETING', meetingID, 'JoinControl::action()', ['called with', {meetingID}]);
 
-    await this.adapter.joinMeeting(meetingID);
+    await this.adapter.joinMeeting(meetingID, {
+      password: meetingPasswordOrPin,
+      name: participantName,
+    });
   }
 
   /**

--- a/src/MeetingsSDKAdapter/controls/JoinControl.test.js
+++ b/src/MeetingsSDKAdapter/controls/JoinControl.test.js
@@ -30,8 +30,20 @@ describe('Join Control', () => {
   describe('action()', () => {
     it('calls joinMeeting() SDK adapter method', async () => {
       meetingsSDKAdapter.joinMeeting = jest.fn();
-      await meetingsSDKAdapter.meetingControls['join-meeting'].action(meetingID);
-      expect(meetingsSDKAdapter.joinMeeting).toHaveBeenCalledWith(meetingID);
+      await meetingsSDKAdapter.meetingControls['join-meeting'].action({meetingID});
+      expect(meetingsSDKAdapter.joinMeeting).toHaveBeenCalledWith(meetingID, {
+        name: undefined,
+        password: undefined,
+      });
+    });
+
+    it('calls joinMeeting() SDK adapter method with pin/password and participant\'s name', async () => {
+      meetingsSDKAdapter.joinMeeting = jest.fn();
+      await meetingsSDKAdapter.meetingControls['join-meeting'].action({meetingID, meetingPasswordOrPin: '123456', participantName: 'name'});
+      expect(meetingsSDKAdapter.joinMeeting).toHaveBeenCalledWith(meetingID, {
+        name: 'name',
+        password: '123456',
+      });
     });
   });
 });

--- a/src/MeetingsSDKAdapter/controls/RosterControl.js
+++ b/src/MeetingsSDKAdapter/controls/RosterControl.js
@@ -18,7 +18,7 @@ export default class RosterControl extends MeetingControl {
    *
    * @param {string} meetingID  Id of the meeting to toggle roster
    */
-  async action(meetingID) {
+  async action({meetingID}) {
     logger.debug('MEETING', meetingID, 'RosterControl::action()', ['called with', {meetingID}]);
 
     await this.adapter.toggleRoster(meetingID);

--- a/src/MeetingsSDKAdapter/controls/RosterControl.test.js
+++ b/src/MeetingsSDKAdapter/controls/RosterControl.test.js
@@ -31,7 +31,7 @@ describe('Roster Control', () => {
   describe('action()', () => {
     it('calls toggleRoster() SDK adapter method', async () => {
       meetingsSDKAdapter.toggleRoster = jest.fn();
-      await meetingsSDKAdapter.meetingControls['member-roster'].action(meetingID);
+      await meetingsSDKAdapter.meetingControls['member-roster'].action({meetingID});
       expect(meetingsSDKAdapter.toggleRoster).toHaveBeenCalledTimes(1);
       expect(meetingsSDKAdapter.toggleRoster).toHaveBeenCalledWith(meetingID);
     });

--- a/src/MeetingsSDKAdapter/controls/SettingsControl.js
+++ b/src/MeetingsSDKAdapter/controls/SettingsControl.js
@@ -18,7 +18,7 @@ export default class SettingsControl extends MeetingControl {
    *
    * @param {string} meetingID  Meeting ID
    */
-  action(meetingID) {
+  action({meetingID}) {
     logger.debug('Meeting', meetingID, 'SettingsControl::action()', ['called with', {meetingID}]);
 
     this.adapter.toggleSettings(meetingID);

--- a/src/MeetingsSDKAdapter/controls/SettingsControl.test.js
+++ b/src/MeetingsSDKAdapter/controls/SettingsControl.test.js
@@ -31,7 +31,7 @@ describe('Settings Control', () => {
   describe('action()', () => {
     it('calls toggleSettings() SDK adapter method', async () => {
       meetingsSDKAdapter.toggleSettings = jest.fn();
-      await meetingsSDKAdapter.meetingControls.settings.action(meetingID);
+      await meetingsSDKAdapter.meetingControls.settings.action({meetingID});
       expect(meetingsSDKAdapter.toggleSettings).toHaveBeenCalledTimes(1);
       expect(meetingsSDKAdapter.toggleSettings).toHaveBeenCalledWith(meetingID);
     });

--- a/src/MeetingsSDKAdapter/controls/ShareControl.js
+++ b/src/MeetingsSDKAdapter/controls/ShareControl.js
@@ -17,7 +17,7 @@ export default class ShareControl extends MeetingControl {
    *
    * @param {string} meetingID  ID of the meeting to share screen
    */
-  async action(meetingID) {
+  async action({meetingID}) {
     logger.debug('MEETING', meetingID, 'ShareControl::action()', ['called with', {meetingID}]);
 
     await this.adapter.handleLocalShare(meetingID);

--- a/src/MeetingsSDKAdapter/controls/ShareControl.test.js
+++ b/src/MeetingsSDKAdapter/controls/ShareControl.test.js
@@ -42,7 +42,7 @@ describe('Share Control', () => {
   describe('action()', () => {
     it('calls handleLocalShare() SDK adapter method', async () => {
       meetingsSDKAdapter.handleLocalShare = jest.fn();
-      await meetingsSDKAdapter.meetingControls['share-screen'].action(meetingID);
+      await meetingsSDKAdapter.meetingControls['share-screen'].action({meetingID});
       expect(meetingsSDKAdapter.handleLocalShare).toHaveBeenCalledTimes(1);
       expect(meetingsSDKAdapter.handleLocalShare).toHaveBeenCalledWith(meetingID);
     });

--- a/src/MeetingsSDKAdapter/controls/SwitchCameraControl.js
+++ b/src/MeetingsSDKAdapter/controls/SwitchCameraControl.js
@@ -17,10 +17,10 @@ export default class SwitchCameraControl extends MeetingControl {
    * @param {string} meetingID  Meeting ID
    * @param {string} cameraID  Id of the camera to switch to
    */
-  async action(meetingID, cameraID) {
+  async action({meetingID, cameraId}) {
     logger.debug('MEETING', meetingID, 'SwitchCameraControl::action()', ['called with', {meetingID}]);
 
-    await this.adapter.switchCamera(meetingID, cameraID);
+    await this.adapter.switchCamera(meetingID, cameraId);
   }
 
   /**

--- a/src/MeetingsSDKAdapter/controls/SwitchCameraControl.test.js
+++ b/src/MeetingsSDKAdapter/controls/SwitchCameraControl.test.js
@@ -45,7 +45,7 @@ describe('Switch Camera Control', () => {
   describe('action()', () => {
     it('calls switchCamera() SDK adapter method', async () => {
       meetingsSDKAdapter.switchCamera = jest.fn();
-      await meetingsSDKAdapter.meetingControls['switch-camera'].action(meetingID, 'cameraID');
+      await meetingsSDKAdapter.meetingControls['switch-camera'].action({meetingID, cameraId: 'cameraID'});
       expect(meetingsSDKAdapter.switchCamera).toHaveBeenCalledTimes(1);
       expect(meetingsSDKAdapter.switchCamera).toHaveBeenCalledWith(meetingID, 'cameraID');
     });

--- a/src/MeetingsSDKAdapter/controls/SwitchMicrophoneControl.js
+++ b/src/MeetingsSDKAdapter/controls/SwitchMicrophoneControl.js
@@ -18,10 +18,10 @@ export default class SwitchMicrophoneControl extends MeetingControl {
    * @param {string} meetingID  Meeting ID
    * @param {string} microphoneID  Id of the microphone to switch to
    */
-  async action(meetingID, microphoneID) {
+  async action({meetingID, microphoneId}) {
     logger.debug('MEETING', meetingID, 'SwitchMicrophoneControl::action()', ['called with', {meetingID}]);
 
-    await this.adapter.switchMicrophone(meetingID, microphoneID);
+    await this.adapter.switchMicrophone(meetingID, microphoneId);
   }
 
   /**

--- a/src/MeetingsSDKAdapter/controls/SwitchMicrophoneControl.test.js
+++ b/src/MeetingsSDKAdapter/controls/SwitchMicrophoneControl.test.js
@@ -60,7 +60,7 @@ describe('Switch Microphone Control', () => {
   describe('action()', () => {
     it('calls switchMicrophone() SDK adapter method', async () => {
       meetingsSDKAdapter.switchMicrophone = jest.fn();
-      await meetingsSDKAdapter.meetingControls['switch-microphone'].action(meetingID, 'microphoneID');
+      await meetingsSDKAdapter.meetingControls['switch-microphone'].action({meetingID, microphoneId: 'microphoneID'});
       expect(meetingsSDKAdapter.switchMicrophone).toHaveBeenCalledTimes(1);
       expect(meetingsSDKAdapter.switchMicrophone).toHaveBeenCalledWith(meetingID, 'microphoneID');
     });

--- a/src/MeetingsSDKAdapter/controls/SwitchSpeakerControl.js
+++ b/src/MeetingsSDKAdapter/controls/SwitchSpeakerControl.js
@@ -17,10 +17,10 @@ export default class SwitchSpeakerControl extends MeetingControl {
    * @param {string} meetingID  Meeting ID
    * @param {string} speakerID  ID of the speaker device to switch to
    */
-  async action(meetingID, speakerID) {
+  async action({meetingID, speakerId}) {
     logger.debug('MEETING', meetingID, 'SwitchSpeakerControl::action()', ['called with', {meetingID}]);
 
-    await this.adapter.switchSpeaker(meetingID, speakerID);
+    await this.adapter.switchSpeaker(meetingID, speakerId);
   }
 
   /**

--- a/src/MeetingsSDKAdapter/controls/SwitchSpeakerControl.test.js
+++ b/src/MeetingsSDKAdapter/controls/SwitchSpeakerControl.test.js
@@ -64,7 +64,7 @@ describe('Switch Speaker Control', () => {
   describe('action()', () => {
     it('calls switchSpeaker() SDK adapter method', async () => {
       meetingsSDKAdapter.switchSpeaker = jest.fn();
-      await meetingsSDKAdapter.meetingControls['switch-speaker'].action(meetingID, 'speakerID');
+      await meetingsSDKAdapter.meetingControls['switch-speaker'].action({meetingID, speakerId: 'speakerID'});
       expect(meetingsSDKAdapter.switchSpeaker).toHaveBeenCalledWith(meetingID, 'speakerID');
     });
   });

--- a/src/MeetingsSDKAdapter/controls/VideoControl.js
+++ b/src/MeetingsSDKAdapter/controls/VideoControl.js
@@ -15,9 +15,9 @@ export default class VideoControl extends MeetingControl {
   /**
    * Calls the adapter handleLocalVideo() method
    *
-   * @param {string} meetingID  Meeting id
+   * @param {meetingID}  Meeting ID to mute video
    */
-  action(meetingID) {
+  action({meetingID}) {
     logger.debug('MEETING', meetingID, 'VideoControl::action()', ['called with', {meetingID}]);
 
     return this.adapter.handleLocalVideo(meetingID);

--- a/src/MeetingsSDKAdapter/controls/VideoControl.test.js
+++ b/src/MeetingsSDKAdapter/controls/VideoControl.test.js
@@ -41,7 +41,7 @@ describe('Video Control', () => {
   describe('action()', () => {
     it('calls handleLocalVideo() SDK adapter method', async () => {
       meetingsSDKAdapter.handleLocalVideo = jest.fn();
-      await meetingsSDKAdapter.meetingControls['mute-video'].action(meetingID);
+      await meetingsSDKAdapter.meetingControls['mute-video'].action({meetingID});
       expect(meetingsSDKAdapter.handleLocalVideo).toHaveBeenCalledTimes(1);
       expect(meetingsSDKAdapter.handleLocalVideo).toHaveBeenCalledWith(meetingID);
     });


### PR DESCRIPTION
### Summary:
Since we've added the password flow into the Webex Meeting Widget, there is an ask for a developer to pass the meeting password as well as participant name programmatically into the Meeting Widget instead of asking users to enter this once the widget loads up. With this PR, developers will now be able to pass participantName and meetingPasswordOrPin props into the WebexMeetingWidget which will allow users to bypass the authentication and directly land into the Interstitial screen where they can set up audio and video.
Post this, they can directly click "Join Meeting" to start the meeting on the widget.

### Benefits:
This allows developers to programmatically insert the password and name into the widget and avoid having to pass this information to a user in an out-of-band manner.

Check the comments in the code for details on changes.

### Change Summary:
1. All actions now take an object as an argument instead of only meetingID. This has been done for future purposes where we'd like to pass in more properties in the action based on the type of action it is. For instance, for switching camera control, we could pass the new camera device ID.
2. JoinControl takes in meeting pin or password as well as participant name so this can be passed to the adapter while joining the meeting

### Tests:
1. Guest joins meeting from widget without name and password. Prompted for this information before joining the meeting.
2. Guest joins meeting from widget with name and password of the meeting. No prompt and directly lands on interstitial screen, followed by joining the meeting
3. Guest joins meeting from widget with name and host pin of the meeting. No prompt and directly lands on interstitial screen, followed by joining the meeting
4. Registered user joins meeting from widget and is not prompted for password.

Vidcast for test scenarios: https://app.vidcast.io/share/90f8051e-7950-4f79-9d63-670c577f7ea3
