### PR TITLE
fix(meeting): resolve control action args for @webex/components contract

### DIFF
--- a/src/MeetingsSDKAdapter.js
+++ b/src/MeetingsSDKAdapter.js
@@ -227,79 +227,87 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
   getStream(ID, mediaDirection, audioVideo) {
     logger.debug('MEETING', ID, 'getStream()', ['called with', {ID, mediaDirection, audioVideo}]);
 
-    return new Observable(async (subscriber) => {
+    return new Observable((subscriber) => {
       let ignored = false;
       let isAsking;
 
-      try {
-        const sdkMeeting = this.fetchMeeting(ID);
+      const ignore = () => {
+        ignored = true;
+        subscriber.next({permission: 'IGNORED', stream: null});
+        subscriber.complete();
+      };
 
-        const ignore = () => {
-          ignored = true;
-          subscriber.next({permission: 'IGNORED', stream: null});
-          subscriber.complete();
-        };
-
-        // wait a bit for the prompt to appear before emitting ASKING
-        isAsking = true;
-        setTimeout(() => {
-          if (isAsking) {
-            // media access promise was neither fulfilled nor rejected, so the browser prompt is probably showing
-            subscriber.next({permission: 'ASKING', stream: null, ignore});
-          }
-        }, 2000);
-
-        const [localStream] = await sdkMeeting.getMediaStreams(mediaDirection, audioVideo);
-        const availableDevices = await navigator.mediaDevices.enumerateDevices();
-        const [{label: deviceLabel}] = localStream.getTracks();
-        const mediaDevice = availableDevices.find((device) => device.label === deviceLabel);
-        const deviceId = mediaDevice && mediaDevice.deviceId;
-
-        isAsking = false;
-
-        for (const track of localStream.getTracks()) {
-          if (track.kind === 'video' && !mediaDirection.sendVideo) {
-            localStream.removeTrack(track);
-          }
-          if (track.kind === 'audio' && !mediaDirection.sendAudio) {
-            localStream.removeTrack(track);
-          }
+      // wait a bit for the prompt to appear before emitting ASKING
+      isAsking = true;
+      const askingTimeout = setTimeout(() => {
+        if (isAsking) {
+          // media access promise was neither fulfilled nor rejected, so the browser prompt is probably showing
+          subscriber.next({permission: 'ASKING', stream: null, ignore});
         }
+      }, 2000);
 
-        if (!ignored) {
-          subscriber.next({permission: 'ALLOWED', stream: localStream, deviceId});
-          subscriber.complete();
-        }
-      } catch (error) {
-        isAsking = false;
+      (async () => {
+        try {
+          const sdkMeeting = this.fetchMeeting(ID);
+          const [localStream] = await sdkMeeting.getMediaStreams(mediaDirection, audioVideo);
+          const availableDevices = await navigator.mediaDevices.enumerateDevices();
+          const [{label: deviceLabel}] = localStream.getTracks();
+          const mediaDevice = availableDevices.find((device) => device.label === deviceLabel);
+          const deviceId = mediaDevice && mediaDevice.deviceId;
 
-        if (!ignored) {
-          let perm;
-          const ee = error.error;
+          isAsking = false;
+          clearTimeout(askingTimeout);
 
-          logger.error('MEETING', ID, 'getStream()', 'Unable to retrieve local media stream', ee || error);
+          for (const track of localStream.getTracks()) {
+            if (track.kind === 'video' && !mediaDirection.sendVideo) {
+              localStream.removeTrack(track);
+            }
+            if (track.kind === 'audio' && !mediaDirection.sendAudio) {
+              localStream.removeTrack(track);
+            }
+          }
 
-          if (ee instanceof DOMException) {
-            if (ee.name === 'NotAllowedError') {
-              if (ee.message === 'Permission dismissed') {
-                perm = 'DISMISSED';
-              } else if (ee.message === 'Permission denied by system') {
+          if (!ignored) {
+            subscriber.next({permission: 'ALLOWED', stream: localStream, deviceId});
+            subscriber.complete();
+          }
+        } catch (error) {
+          isAsking = false;
+          clearTimeout(askingTimeout);
+
+          if (!ignored) {
+            let perm;
+            const ee = error.error;
+
+            logger.error('MEETING', ID, 'getStream()', 'Unable to retrieve local media stream', ee || error);
+
+            if (ee instanceof DOMException) {
+              if (ee.name === 'NotAllowedError') {
+                if (ee.message === 'Permission dismissed') {
+                  perm = 'DISMISSED';
+                } else if (ee.message === 'Permission denied by system') {
+                  perm = 'DISABLED';
+                } else {
+                  perm = 'DENIED';
+                }
+              } else if (ee.name === 'NotReadableError') {
                 perm = 'DISABLED';
               } else {
-                perm = 'DENIED';
+                perm = 'ERROR';
               }
-            } else if (ee.name === 'NotReadableError') {
-              perm = 'DISABLED';
             } else {
               perm = 'ERROR';
             }
-          } else {
-            perm = 'ERROR';
+            subscriber.next({permission: perm, stream: null});
+            subscriber.complete();
           }
-          subscriber.next({permission: perm, stream: null});
-          subscriber.complete();
         }
-      }
+      })();
+
+      return () => {
+        isAsking = false;
+        clearTimeout(askingTimeout);
+      };
     });
   }
 
@@ -1061,7 +1069,7 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
       const {stream, permission, deviceId} = await this.getStream(
         ID,
         {sendVideo: true},
-        {video: {deviceId: cameraID}},
+        {video: {deviceId: cameraID === 'default' ? 'default' : {exact: cameraID}}},
       ).toPromise();
 
       if (stream) {
@@ -1092,6 +1100,11 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
   async switchMicrophone(ID, microphoneID) {
     logger.debug('MEETING', ID, 'switchMicrophone()', ['called with', {ID, microphoneID}]);
     logger.info('MEETING', ID, 'SWITCH MICROPHONE', `Switching current microphone to microphone with id "${microphoneID}"`);
+
+    const audioConstraints = {
+      deviceId: microphoneID === 'default' ? 'default' : {exact: microphoneID},
+    };
+
     await this.updateMeeting(ID, async (meeting) => {
       let updates;
 
@@ -1099,7 +1112,7 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
       const {stream, permission, deviceId} = await this.getStream(
         ID,
         {sendAudio: true},
-        {audio: {deviceId: microphoneID}},
+        {audio: audioConstraints},
       ).toPromise();
 
       if (stream) {

--- a/src/MeetingsSDKAdapter.js
+++ b/src/MeetingsSDKAdapter.js
@@ -1159,7 +1159,7 @@ export default class MeetingsSDKAdapter extends MeetingsAdapter {
     logger.debug('MEETING', ID, 'switchSpeaker()', ['called with', {ID, speakerID}]);
     logger.info('MEETING', ID, 'SWITCH SPEAKER', `Switching current speaker to speaker with id "${speakerID}"`);
 
-    return this.updateMeeting(ID, () => ({speakerID}));
+    await this.updateMeeting(ID, () => ({speakerID}));
   }
 
   /**

--- a/src/MeetingsSDKAdapter.test.js
+++ b/src/MeetingsSDKAdapter.test.js
@@ -9,6 +9,13 @@ import {meetingID, createTestMeetingsSDKAdapter} from './MeetingsSDKAdapter/test
 
 import logger from './logger';
 
+class MockDOMException extends Error {
+  constructor(message, name) {
+    super(message);
+    this.name = name;
+  }
+}
+
 describe('Meetings SDK Adapter', () => {
   let meeting;
   let meetingsSDKAdapter;
@@ -97,6 +104,36 @@ describe('Meetings SDK Adapter', () => {
             'Unable to retrieve local media stream',
             sdkError.error,
           );
+          done();
+        },
+      );
+    });
+
+    it('returns DENIED when media access is not allowed', (done) => {
+      global.DOMException = MockDOMException;
+      const sdkError = {error: new MockDOMException('Permission denied', 'NotAllowedError')};
+
+      logger.error = jest.fn();
+      mockSDKMeeting.getMediaStreams = jest.fn(() => Promise.reject(sdkError));
+      meetingsSDKAdapter.getStream(meetingID, {sendAudio: true}).pipe(last()).subscribe(
+        ({permission, stream}) => {
+          expect(stream).toBeNull();
+          expect(permission).toBe('DENIED');
+          done();
+        },
+      );
+    });
+
+    it('returns DISABLED when the media device is not readable', (done) => {
+      global.DOMException = MockDOMException;
+      const sdkError = {error: new MockDOMException('Could not start video source', 'NotReadableError')};
+
+      logger.error = jest.fn();
+      mockSDKMeeting.getMediaStreams = jest.fn(() => Promise.reject(sdkError));
+      meetingsSDKAdapter.getStream(meetingID, {sendVideo: true}).pipe(last()).subscribe(
+        ({permission, stream}) => {
+          expect(stream).toBeNull();
+          expect(permission).toBe('DISABLED');
           done();
         },
       );

--- a/src/MeetingsSDKAdapter.test.js
+++ b/src/MeetingsSDKAdapter.test.js
@@ -942,9 +942,31 @@ describe('Meetings SDK Adapter', () => {
       meetingsSDKAdapter.getStream = jest.fn(() => ({stream: new MediaStream(), deviceId: '', toPromise: () => Promise.resolve({stream: new MediaStream(), permission: 'ALLOWED', deviceId: 'example-camera-id'})}));
       await meetingsSDKAdapter.switchCamera(meetingID, 'example-camera-id');
 
+      expect(meetingsSDKAdapter.getStream).toHaveBeenCalledWith(
+        meetingID,
+        {sendVideo: true},
+        {video: {deviceId: {exact: 'example-camera-id'}}},
+      );
       expect(mockSDKMeeting.emit).toHaveBeenCalledTimes(1);
       expect(mockSDKMeeting.emit.mock.calls[0][0]).toBe('adapter:meeting:updated');
       expect(mockSDKMeeting.emit.mock.calls[0][1]).toMatchObject({cameraID: 'example-camera-id'});
+    });
+
+    it('uses plain default deviceId constraint for the default alias', async () => {
+      meetingsSDKAdapter.getStream = jest.fn(() => ({
+        toPromise: () => Promise.resolve({
+          stream: new MediaStream(),
+          permission: 'ALLOWED',
+          deviceId: 'default',
+        }),
+      }));
+      await meetingsSDKAdapter.switchCamera(meetingID, 'default');
+
+      expect(meetingsSDKAdapter.getStream).toHaveBeenCalledWith(
+        meetingID,
+        {sendVideo: true},
+        {video: {deviceId: 'default'}},
+      );
     });
 
     it('returns a rejected promise if meeting does not exist', async () => {
@@ -968,9 +990,31 @@ describe('Meetings SDK Adapter', () => {
       meetingsSDKAdapter.getStream = jest.fn(() => ({stream: new MediaStream(), deviceId: '', toPromise: () => Promise.resolve({stream: new MediaStream(), permission: 'ALLOWED', deviceId: 'example-microphone-id'})}));
       await meetingsSDKAdapter.switchMicrophone(meetingID, 'example-microphone-id');
 
+      expect(meetingsSDKAdapter.getStream).toHaveBeenCalledWith(
+        meetingID,
+        {sendAudio: true},
+        {audio: {deviceId: {exact: 'example-microphone-id'}}},
+      );
       expect(mockSDKMeeting.emit).toHaveBeenCalledTimes(1);
       expect(mockSDKMeeting.emit.mock.calls[0][0]).toBe('adapter:meeting:updated');
       expect(mockSDKMeeting.emit.mock.calls[0][1]).toMatchObject({microphoneID: 'example-microphone-id'});
+    });
+
+    it('uses plain default deviceId constraint for the default alias', async () => {
+      meetingsSDKAdapter.getStream = jest.fn(() => ({
+        toPromise: () => Promise.resolve({
+          stream: new MediaStream(),
+          permission: 'ALLOWED',
+          deviceId: 'default',
+        }),
+      }));
+      await meetingsSDKAdapter.switchMicrophone(meetingID, 'default');
+
+      expect(meetingsSDKAdapter.getStream).toHaveBeenCalledWith(
+        meetingID,
+        {sendAudio: true},
+        {audio: {deviceId: 'default'}},
+      );
     });
 
     it('returns a rejected promise if meeting does not exist', async () => {

--- a/src/MeetingsSDKAdapter/controls/AudioControl.js
+++ b/src/MeetingsSDKAdapter/controls/AudioControl.js
@@ -3,6 +3,7 @@ import {distinctUntilChanged, map, tap} from 'rxjs/operators';
 import {MeetingControlState} from '@webex/component-adapter-interfaces';
 import logger from '../../logger';
 import MeetingControl from './MeetingControl';
+import {resolveMeetingID} from '../../utils';
 
 /**
  * Display options of a meeting control.
@@ -18,7 +19,9 @@ export default class AudioControl extends MeetingControl {
    * @private
    * @param {meetingID}  ID of the meeting to mute audio
    */
-  action({meetingID}) {
+  action(contextOrMeetingID) {
+    const meetingID = resolveMeetingID(contextOrMeetingID);
+
     logger.debug('MEETING', meetingID, 'AudioControl::action()', ['called with', {meetingID}]);
 
     return this.adapter.handleLocalAudio(meetingID);

--- a/src/MeetingsSDKAdapter/controls/AudioControl.js
+++ b/src/MeetingsSDKAdapter/controls/AudioControl.js
@@ -19,8 +19,8 @@ export default class AudioControl extends MeetingControl {
    * @private
    * @param {meetingID}  ID of the meeting to mute audio
    */
-  action(contextOrMeetingID) {
-    const meetingID = resolveMeetingID(contextOrMeetingID);
+  action(meetingContext) {
+    const meetingID = resolveMeetingID(meetingContext);
 
     logger.debug('MEETING', meetingID, 'AudioControl::action()', ['called with', {meetingID}]);
 

--- a/src/MeetingsSDKAdapter/controls/AudioControl.test.js
+++ b/src/MeetingsSDKAdapter/controls/AudioControl.test.js
@@ -45,5 +45,11 @@ describe('Audio Control', () => {
       expect(meetingsSDKAdapter.handleLocalAudio).toHaveBeenCalledTimes(1);
       expect(meetingsSDKAdapter.handleLocalAudio).toHaveBeenCalledWith(meetingID);
     });
+
+    it('calls handleLocalAudio() with meeting ID passed as a string', async () => {
+      meetingsSDKAdapter.handleLocalAudio = jest.fn();
+      await meetingsSDKAdapter.meetingControls['mute-audio'].action(meetingID);
+      expect(meetingsSDKAdapter.handleLocalAudio.mock.calls).toEqual([[meetingID]]);
+    });
   });
 });

--- a/src/MeetingsSDKAdapter/controls/ExitControl.js
+++ b/src/MeetingsSDKAdapter/controls/ExitControl.js
@@ -2,6 +2,7 @@ import {Observable, of} from 'rxjs';
 import {tap} from 'rxjs/operators';
 import logger from '../../logger';
 import MeetingControl from './MeetingControl';
+import {resolveMeetingID} from '../../utils';
 
 /**
  * Display options of a meeting control.
@@ -16,7 +17,9 @@ export default class ExitControl extends MeetingControl {
    *
    * @param {string} meetingID  Id of the meeting to leave from
    */
-  async action({meetingID}) {
+  async action(contextOrMeetingID) {
+    const meetingID = resolveMeetingID(contextOrMeetingID);
+
     logger.debug('MEETING', meetingID, 'ExitControl::action()', ['called with', {meetingID}]);
 
     await this.adapter.leaveMeeting(meetingID);

--- a/src/MeetingsSDKAdapter/controls/ExitControl.js
+++ b/src/MeetingsSDKAdapter/controls/ExitControl.js
@@ -17,8 +17,8 @@ export default class ExitControl extends MeetingControl {
    *
    * @param {string} meetingID  Id of the meeting to leave from
    */
-  async action(contextOrMeetingID) {
-    const meetingID = resolveMeetingID(contextOrMeetingID);
+  async action(meetingContext) {
+    const meetingID = resolveMeetingID(meetingContext);
 
     logger.debug('MEETING', meetingID, 'ExitControl::action()', ['called with', {meetingID}]);
 

--- a/src/MeetingsSDKAdapter/controls/ExitControl.test.js
+++ b/src/MeetingsSDKAdapter/controls/ExitControl.test.js
@@ -32,5 +32,11 @@ describe('Exit Control', () => {
       await meetingsSDKAdapter.meetingControls['leave-meeting'].action({meetingID});
       expect(meetingsSDKAdapter.leaveMeeting).toHaveBeenCalledWith(meetingID);
     });
+
+    it('calls leaveMeeting() with meeting ID passed as a string', async () => {
+      meetingsSDKAdapter.leaveMeeting = jest.fn();
+      await meetingsSDKAdapter.meetingControls['leave-meeting'].action(meetingID);
+      expect(meetingsSDKAdapter.leaveMeeting.mock.calls).toEqual([[meetingID]]);
+    });
   });
 });

--- a/src/MeetingsSDKAdapter/controls/JoinControl.js
+++ b/src/MeetingsSDKAdapter/controls/JoinControl.js
@@ -3,6 +3,7 @@ import {distinctUntilChanged, map, tap} from 'rxjs/operators';
 import {MeetingControlState} from '@webex/component-adapter-interfaces';
 import logger from '../../logger';
 import MeetingControl from './MeetingControl';
+import {resolveMeetingID} from '../../utils';
 
 /**
  * Display options of a meeting control.
@@ -15,24 +16,20 @@ export default class JoinControl extends MeetingControl {
   /**
    * Calls the adapter joinMeeting method.
    *
-   * @param {meetingID, meetingPasswordOrPin}
+   * @param {object|string} meetingContext  Meeting ID string or context with password and name
    */
-  async action(contextOrMeetingID) {
-    if (typeof contextOrMeetingID === 'string') {
-      logger.debug('MEETING', contextOrMeetingID, 'JoinControl::action()', ['called with', {meetingID: contextOrMeetingID}]);
-      await this.adapter.joinMeeting(contextOrMeetingID, {});
-
-      return;
-    }
-
-    const {meetingID, meetingPasswordOrPin, participantName} = contextOrMeetingID;
+  async action(meetingContext) {
+    const meetingID = resolveMeetingID(meetingContext);
+    const joinOptions = typeof meetingContext === 'string'
+      ? {}
+      : {
+        password: meetingContext.meetingPasswordOrPin,
+        name: meetingContext.participantName,
+      };
 
     logger.debug('MEETING', meetingID, 'JoinControl::action()', ['called with', {meetingID}]);
 
-    await this.adapter.joinMeeting(meetingID, {
-      password: meetingPasswordOrPin,
-      name: participantName,
-    });
+    await this.adapter.joinMeeting(meetingID, joinOptions);
   }
 
   /**

--- a/src/MeetingsSDKAdapter/controls/JoinControl.js
+++ b/src/MeetingsSDKAdapter/controls/JoinControl.js
@@ -17,7 +17,16 @@ export default class JoinControl extends MeetingControl {
    *
    * @param {meetingID, meetingPasswordOrPin}
    */
-  async action({meetingID, meetingPasswordOrPin, participantName}) {
+  async action(contextOrMeetingID) {
+    if (typeof contextOrMeetingID === 'string') {
+      logger.debug('MEETING', contextOrMeetingID, 'JoinControl::action()', ['called with', {meetingID: contextOrMeetingID}]);
+      await this.adapter.joinMeeting(contextOrMeetingID, {});
+
+      return;
+    }
+
+    const {meetingID, meetingPasswordOrPin, participantName} = contextOrMeetingID;
+
     logger.debug('MEETING', meetingID, 'JoinControl::action()', ['called with', {meetingID}]);
 
     await this.adapter.joinMeeting(meetingID, {

--- a/src/MeetingsSDKAdapter/controls/JoinControl.test.js
+++ b/src/MeetingsSDKAdapter/controls/JoinControl.test.js
@@ -37,6 +37,12 @@ describe('Join Control', () => {
       });
     });
 
+    it('calls joinMeeting() with meeting ID passed as a string', async () => {
+      meetingsSDKAdapter.joinMeeting = jest.fn();
+      await meetingsSDKAdapter.meetingControls['join-meeting'].action(meetingID);
+      expect(meetingsSDKAdapter.joinMeeting).toHaveBeenCalledWith(meetingID, {});
+    });
+
     it('calls joinMeeting() SDK adapter method with pin/password and participant\'s name', async () => {
       meetingsSDKAdapter.joinMeeting = jest.fn();
       await meetingsSDKAdapter.meetingControls['join-meeting'].action({meetingID, meetingPasswordOrPin: '123456', participantName: 'name'});

--- a/src/MeetingsSDKAdapter/controls/RosterControl.js
+++ b/src/MeetingsSDKAdapter/controls/RosterControl.js
@@ -3,6 +3,7 @@ import {distinctUntilChanged, map, tap} from 'rxjs/operators';
 import {MeetingControlState} from '@webex/component-adapter-interfaces';
 import logger from '../../logger';
 import MeetingControl from './MeetingControl';
+import {resolveMeetingID} from '../../utils';
 
 /**
  * Display options of a meeting control.
@@ -18,7 +19,9 @@ export default class RosterControl extends MeetingControl {
    *
    * @param {string} meetingID  Id of the meeting to toggle roster
    */
-  async action({meetingID}) {
+  async action(contextOrMeetingID) {
+    const meetingID = resolveMeetingID(contextOrMeetingID);
+
     logger.debug('MEETING', meetingID, 'RosterControl::action()', ['called with', {meetingID}]);
 
     await this.adapter.toggleRoster(meetingID);

--- a/src/MeetingsSDKAdapter/controls/RosterControl.js
+++ b/src/MeetingsSDKAdapter/controls/RosterControl.js
@@ -19,8 +19,8 @@ export default class RosterControl extends MeetingControl {
    *
    * @param {string} meetingID  Id of the meeting to toggle roster
    */
-  async action(contextOrMeetingID) {
-    const meetingID = resolveMeetingID(contextOrMeetingID);
+  async action(meetingContext) {
+    const meetingID = resolveMeetingID(meetingContext);
 
     logger.debug('MEETING', meetingID, 'RosterControl::action()', ['called with', {meetingID}]);
 

--- a/src/MeetingsSDKAdapter/controls/RosterControl.test.js
+++ b/src/MeetingsSDKAdapter/controls/RosterControl.test.js
@@ -35,5 +35,11 @@ describe('Roster Control', () => {
       expect(meetingsSDKAdapter.toggleRoster).toHaveBeenCalledTimes(1);
       expect(meetingsSDKAdapter.toggleRoster).toHaveBeenCalledWith(meetingID);
     });
+
+    it('calls toggleRoster() with meeting ID passed as a string', async () => {
+      meetingsSDKAdapter.toggleRoster = jest.fn();
+      await meetingsSDKAdapter.meetingControls['member-roster'].action(meetingID);
+      expect(meetingsSDKAdapter.toggleRoster.mock.calls).toEqual([[meetingID]]);
+    });
   });
 });

--- a/src/MeetingsSDKAdapter/controls/SettingsControl.js
+++ b/src/MeetingsSDKAdapter/controls/SettingsControl.js
@@ -17,11 +17,11 @@ export default class SettingsControl extends MeetingControl {
    * Toggles the showSettings flag of the given meeting ID.
    * A settings toggle event is dispatched.
    *
-   * @param {object|string} context  Meeting control context or meeting ID string
-   * @param {string} [context.meetingID]  Meeting ID when passed on the context object (PR #346 call shape)
+   * @param {object|string} meetingContext  Meeting control context or meeting ID string
+   * @param {string} [meetingContext.meetingID]  Meeting ID when passed on the context object (PR #346 call shape)
    */
-  action(contextOrMeetingID) {
-    const meetingID = resolveMeetingID(contextOrMeetingID);
+  action(meetingContext) {
+    const meetingID = resolveMeetingID(meetingContext);
 
     logger.debug('Meeting', meetingID, 'SettingsControl::action()', ['called with', {meetingID}]);
 

--- a/src/MeetingsSDKAdapter/controls/SettingsControl.js
+++ b/src/MeetingsSDKAdapter/controls/SettingsControl.js
@@ -3,6 +3,7 @@ import {distinctUntilChanged, map, tap} from 'rxjs/operators';
 import {MeetingControlState} from '@webex/component-adapter-interfaces';
 import logger from '../../logger';
 import MeetingControl from './MeetingControl';
+import {resolveMeetingID} from '../../utils';
 
 /**
  * Display options of a meeting control.
@@ -16,9 +17,12 @@ export default class SettingsControl extends MeetingControl {
    * Toggles the showSettings flag of the given meeting ID.
    * A settings toggle event is dispatched.
    *
-   * @param {string} meetingID  Meeting ID
+   * @param {object|string} context  Meeting control context or meeting ID string
+   * @param {string} [context.meetingID]  Meeting ID when passed on the context object (PR #346 call shape)
    */
-  action({meetingID}) {
+  action(contextOrMeetingID) {
+    const meetingID = resolveMeetingID(contextOrMeetingID);
+
     logger.debug('Meeting', meetingID, 'SettingsControl::action()', ['called with', {meetingID}]);
 
     this.adapter.toggleSettings(meetingID);

--- a/src/MeetingsSDKAdapter/controls/SettingsControl.test.js
+++ b/src/MeetingsSDKAdapter/controls/SettingsControl.test.js
@@ -29,11 +29,16 @@ describe('Settings Control', () => {
   });
 
   describe('action()', () => {
-    it('calls toggleSettings() SDK adapter method', async () => {
+    it('calls toggleSettings() SDK adapter method with context object', async () => {
       meetingsSDKAdapter.toggleSettings = jest.fn();
       await meetingsSDKAdapter.meetingControls.settings.action({meetingID});
-      expect(meetingsSDKAdapter.toggleSettings).toHaveBeenCalledTimes(1);
-      expect(meetingsSDKAdapter.toggleSettings).toHaveBeenCalledWith(meetingID);
+      expect(meetingsSDKAdapter.toggleSettings.mock.calls).toEqual([[meetingID]]);
+    });
+
+    it('calls toggleSettings() with meeting ID passed as a string', async () => {
+      meetingsSDKAdapter.toggleSettings = jest.fn();
+      await meetingsSDKAdapter.meetingControls.settings.action(meetingID);
+      expect(meetingsSDKAdapter.toggleSettings.mock.calls).toEqual([[meetingID]]);
     });
   });
 });

--- a/src/MeetingsSDKAdapter/controls/ShareControl.js
+++ b/src/MeetingsSDKAdapter/controls/ShareControl.js
@@ -18,8 +18,8 @@ export default class ShareControl extends MeetingControl {
    *
    * @param {string} meetingID  ID of the meeting to share screen
    */
-  async action(contextOrMeetingID) {
-    const meetingID = resolveMeetingID(contextOrMeetingID);
+  async action(meetingContext) {
+    const meetingID = resolveMeetingID(meetingContext);
 
     logger.debug('MEETING', meetingID, 'ShareControl::action()', ['called with', {meetingID}]);
 

--- a/src/MeetingsSDKAdapter/controls/ShareControl.js
+++ b/src/MeetingsSDKAdapter/controls/ShareControl.js
@@ -3,6 +3,7 @@ import {distinctUntilChanged, map, tap} from 'rxjs/operators';
 import {MeetingControlState} from '@webex/component-adapter-interfaces';
 import logger from '../../logger';
 import MeetingControl from './MeetingControl';
+import {resolveMeetingID} from '../../utils';
 
 /**
  * Display options of a meeting control.
@@ -17,7 +18,9 @@ export default class ShareControl extends MeetingControl {
    *
    * @param {string} meetingID  ID of the meeting to share screen
    */
-  async action({meetingID}) {
+  async action(contextOrMeetingID) {
+    const meetingID = resolveMeetingID(contextOrMeetingID);
+
     logger.debug('MEETING', meetingID, 'ShareControl::action()', ['called with', {meetingID}]);
 
     await this.adapter.handleLocalShare(meetingID);

--- a/src/MeetingsSDKAdapter/controls/ShareControl.test.js
+++ b/src/MeetingsSDKAdapter/controls/ShareControl.test.js
@@ -46,5 +46,11 @@ describe('Share Control', () => {
       expect(meetingsSDKAdapter.handleLocalShare).toHaveBeenCalledTimes(1);
       expect(meetingsSDKAdapter.handleLocalShare).toHaveBeenCalledWith(meetingID);
     });
+
+    it('calls handleLocalShare() with meeting ID passed as a string', async () => {
+      meetingsSDKAdapter.handleLocalShare = jest.fn();
+      await meetingsSDKAdapter.meetingControls['share-screen'].action(meetingID);
+      expect(meetingsSDKAdapter.handleLocalShare.mock.calls).toEqual([[meetingID]]);
+    });
   });
 });

--- a/src/MeetingsSDKAdapter/controls/SwitchCameraControl.js
+++ b/src/MeetingsSDKAdapter/controls/SwitchCameraControl.js
@@ -2,7 +2,7 @@ import {Observable} from 'rxjs';
 import {distinctUntilChanged, map, tap} from 'rxjs/operators';
 import logger from '../../logger';
 import MeetingControl from './MeetingControl';
-import {combineLatestImmediate} from '../../utils';
+import {combineLatestImmediate, resolveDeviceSwitchArgs} from '../../utils';
 /**
  * Display options of a meeting control.
  *
@@ -14,14 +14,23 @@ export default class SwitchCameraControl extends MeetingControl {
   /**
    * Calls the action of the switch camera control.
    *
-   * @param {object} context  Meeting control context
-   * @param {string} context.meetingID  Meeting ID
-   * @param {string} [context.cameraId]  Id of the camera to switch to
-   * @param {string} [deviceId]  Id of the camera to switch to (passed by @webex/components)
+   * @param {object|string} contextOrMeetingID  Meeting context object or meeting ID string (@webex/components)
+   * @param {string} context.meetingID  Meeting ID when passed on the context object (PR #346 call shape)
+   * @param {string} [context.cameraId]  Camera device ID on the context object (PR #346 call shape)
+   * @param {string} [deviceId]  Camera device ID as the second argument (@webex/components call shape)
    */
-  async action(context, deviceId) {
-    const {meetingID} = context;
-    const cameraId = context.cameraId != null ? context.cameraId : deviceId;
+  async action(contextOrMeetingID, deviceId) {
+    const {meetingID, deviceId: cameraId} = resolveDeviceSwitchArgs(
+      contextOrMeetingID,
+      deviceId,
+      'cameraId',
+    );
+
+    if (cameraId == null) {
+      logger.warn('MEETING', meetingID, 'SwitchCameraControl::action()', 'No camera device ID provided');
+
+      return;
+    }
 
     logger.debug('MEETING', meetingID, 'SwitchCameraControl::action()', ['called with', {meetingID, cameraId}]);
 

--- a/src/MeetingsSDKAdapter/controls/SwitchCameraControl.js
+++ b/src/MeetingsSDKAdapter/controls/SwitchCameraControl.js
@@ -14,11 +14,16 @@ export default class SwitchCameraControl extends MeetingControl {
   /**
    * Calls the action of the switch camera control.
    *
-   * @param {string} meetingID  Meeting ID
-   * @param {string} cameraID  Id of the camera to switch to
+   * @param {object} context  Meeting control context
+   * @param {string} context.meetingID  Meeting ID
+   * @param {string} [context.cameraId]  Id of the camera to switch to
+   * @param {string} [deviceId]  Id of the camera to switch to (passed by @webex/components)
    */
-  async action({meetingID, cameraId}) {
-    logger.debug('MEETING', meetingID, 'SwitchCameraControl::action()', ['called with', {meetingID}]);
+  async action(context, deviceId) {
+    const {meetingID} = context;
+    const cameraId = context.cameraId != null ? context.cameraId : deviceId;
+
+    logger.debug('MEETING', meetingID, 'SwitchCameraControl::action()', ['called with', {meetingID, cameraId}]);
 
     await this.adapter.switchCamera(meetingID, cameraId);
   }

--- a/src/MeetingsSDKAdapter/controls/SwitchCameraControl.js
+++ b/src/MeetingsSDKAdapter/controls/SwitchCameraControl.js
@@ -14,14 +14,14 @@ export default class SwitchCameraControl extends MeetingControl {
   /**
    * Calls the action of the switch camera control.
    *
-   * @param {object|string} contextOrMeetingID  Meeting context object or meeting ID string (@webex/components)
-   * @param {string} context.meetingID  Meeting ID when passed on the context object (PR #346 call shape)
-   * @param {string} [context.cameraId]  Camera device ID on the context object (PR #346 call shape)
+   * @param {object|string} meetingContext  Meeting context object or meeting ID string (@webex/components)
+   * @param {string} [meetingContext.meetingID]  Meeting ID when passed on the context object (PR #346 call shape)
+   * @param {string} [meetingContext.cameraId]  Camera device ID on the context object (PR #346 call shape)
    * @param {string} [deviceId]  Camera device ID as the second argument (@webex/components call shape)
    */
-  async action(contextOrMeetingID, deviceId) {
+  async action(meetingContext, deviceId) {
     const {meetingID, deviceId: cameraId} = resolveDeviceSwitchArgs(
-      contextOrMeetingID,
+      meetingContext,
       deviceId,
       'cameraId',
     );

--- a/src/MeetingsSDKAdapter/controls/SwitchCameraControl.test.js
+++ b/src/MeetingsSDKAdapter/controls/SwitchCameraControl.test.js
@@ -49,5 +49,12 @@ describe('Switch Camera Control', () => {
       expect(meetingsSDKAdapter.switchCamera).toHaveBeenCalledTimes(1);
       expect(meetingsSDKAdapter.switchCamera).toHaveBeenCalledWith(meetingID, 'cameraID');
     });
+
+    it('calls switchCamera() with device ID passed as second argument', async () => {
+      meetingsSDKAdapter.switchCamera = jest.fn();
+      await meetingsSDKAdapter.meetingControls['switch-camera'].action({meetingID}, 'cameraID');
+      expect(meetingsSDKAdapter.switchCamera).toHaveBeenCalledTimes(1);
+      expect(meetingsSDKAdapter.switchCamera).toHaveBeenCalledWith(meetingID, 'cameraID');
+    });
   });
 });

--- a/src/MeetingsSDKAdapter/controls/SwitchCameraControl.test.js
+++ b/src/MeetingsSDKAdapter/controls/SwitchCameraControl.test.js
@@ -43,18 +43,37 @@ describe('Switch Camera Control', () => {
   });
 
   describe('action()', () => {
-    it('calls switchCamera() SDK adapter method', async () => {
+    it('calls switchCamera() with camera ID on the context object', async () => {
       meetingsSDKAdapter.switchCamera = jest.fn();
       await meetingsSDKAdapter.meetingControls['switch-camera'].action({meetingID, cameraId: 'cameraID'});
-      expect(meetingsSDKAdapter.switchCamera).toHaveBeenCalledTimes(1);
-      expect(meetingsSDKAdapter.switchCamera).toHaveBeenCalledWith(meetingID, 'cameraID');
+      expect(meetingsSDKAdapter.switchCamera.mock.calls).toEqual([[meetingID, 'cameraID']]);
     });
 
     it('calls switchCamera() with device ID passed as second argument', async () => {
       meetingsSDKAdapter.switchCamera = jest.fn();
       await meetingsSDKAdapter.meetingControls['switch-camera'].action({meetingID}, 'cameraID');
-      expect(meetingsSDKAdapter.switchCamera).toHaveBeenCalledTimes(1);
-      expect(meetingsSDKAdapter.switchCamera).toHaveBeenCalledWith(meetingID, 'cameraID');
+      expect(meetingsSDKAdapter.switchCamera.mock.calls).toEqual([[meetingID, 'cameraID']]);
+    });
+
+    it('calls switchCamera() with meeting ID and device ID passed as strings', async () => {
+      meetingsSDKAdapter.switchCamera = jest.fn();
+      await meetingsSDKAdapter.meetingControls['switch-camera'].action(meetingID, 'cameraID');
+      expect(meetingsSDKAdapter.switchCamera.mock.calls).toEqual([[meetingID, 'cameraID']]);
+    });
+
+    it('prefers context camera ID when both context and second argument are provided', async () => {
+      meetingsSDKAdapter.switchCamera = jest.fn();
+      await meetingsSDKAdapter.meetingControls['switch-camera'].action(
+        {meetingID, cameraId: 'context-camera'},
+        'second-arg-camera',
+      );
+      expect(meetingsSDKAdapter.switchCamera.mock.calls).toEqual([[meetingID, 'context-camera']]);
+    });
+
+    it('does not call switchCamera() when no device ID is provided', async () => {
+      meetingsSDKAdapter.switchCamera = jest.fn();
+      await meetingsSDKAdapter.meetingControls['switch-camera'].action({meetingID});
+      expect(meetingsSDKAdapter.switchCamera).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/MeetingsSDKAdapter/controls/SwitchMicrophoneControl.js
+++ b/src/MeetingsSDKAdapter/controls/SwitchMicrophoneControl.js
@@ -2,7 +2,7 @@ import {Observable} from 'rxjs';
 import {distinctUntilChanged, map, tap} from 'rxjs/operators';
 import logger from '../../logger';
 import MeetingControl from './MeetingControl';
-import {combineLatestImmediate} from '../../utils';
+import {combineLatestImmediate, resolveDeviceSwitchArgs} from '../../utils';
 
 /**
  * Display options of a meeting control.
@@ -15,14 +15,23 @@ export default class SwitchMicrophoneControl extends MeetingControl {
   /**
    * Switches the microphone control.
    *
-   * @param {object} context  Meeting control context
-   * @param {string} context.meetingID  Meeting ID
-   * @param {string} [context.microphoneId]  Id of the microphone to switch to
-   * @param {string} [deviceId]  Id of the microphone to switch to (passed by @webex/components)
+   * @param {object|string} contextOrMeetingID  Meeting context object or meeting ID string (@webex/components)
+   * @param {string} context.meetingID  Meeting ID when passed on the context object (PR #346 call shape)
+   * @param {string} [context.microphoneId]  Microphone device ID on the context object (PR #346 call shape)
+   * @param {string} [deviceId]  Microphone device ID as the second argument (@webex/components call shape)
    */
-  async action(context, deviceId) {
-    const {meetingID} = context;
-    const microphoneId = context.microphoneId != null ? context.microphoneId : deviceId;
+  async action(contextOrMeetingID, deviceId) {
+    const {meetingID, deviceId: microphoneId} = resolveDeviceSwitchArgs(
+      contextOrMeetingID,
+      deviceId,
+      'microphoneId',
+    );
+
+    if (microphoneId == null) {
+      logger.warn('MEETING', meetingID, 'SwitchMicrophoneControl::action()', 'No microphone device ID provided');
+
+      return;
+    }
 
     logger.debug('MEETING', meetingID, 'SwitchMicrophoneControl::action()', ['called with', {meetingID, microphoneId}]);
 

--- a/src/MeetingsSDKAdapter/controls/SwitchMicrophoneControl.js
+++ b/src/MeetingsSDKAdapter/controls/SwitchMicrophoneControl.js
@@ -15,11 +15,16 @@ export default class SwitchMicrophoneControl extends MeetingControl {
   /**
    * Switches the microphone control.
    *
-   * @param {string} meetingID  Meeting ID
-   * @param {string} microphoneID  Id of the microphone to switch to
+   * @param {object} context  Meeting control context
+   * @param {string} context.meetingID  Meeting ID
+   * @param {string} [context.microphoneId]  Id of the microphone to switch to
+   * @param {string} [deviceId]  Id of the microphone to switch to (passed by @webex/components)
    */
-  async action({meetingID, microphoneId}) {
-    logger.debug('MEETING', meetingID, 'SwitchMicrophoneControl::action()', ['called with', {meetingID}]);
+  async action(context, deviceId) {
+    const {meetingID} = context;
+    const microphoneId = context.microphoneId != null ? context.microphoneId : deviceId;
+
+    logger.debug('MEETING', meetingID, 'SwitchMicrophoneControl::action()', ['called with', {meetingID, microphoneId}]);
 
     await this.adapter.switchMicrophone(meetingID, microphoneId);
   }

--- a/src/MeetingsSDKAdapter/controls/SwitchMicrophoneControl.js
+++ b/src/MeetingsSDKAdapter/controls/SwitchMicrophoneControl.js
@@ -15,14 +15,14 @@ export default class SwitchMicrophoneControl extends MeetingControl {
   /**
    * Switches the microphone control.
    *
-   * @param {object|string} contextOrMeetingID  Meeting context object or meeting ID string (@webex/components)
-   * @param {string} context.meetingID  Meeting ID when passed on the context object (PR #346 call shape)
-   * @param {string} [context.microphoneId]  Microphone device ID on the context object (PR #346 call shape)
+   * @param {object|string} meetingContext  Meeting context object or meeting ID string (@webex/components)
+   * @param {string} [meetingContext.meetingID]  Meeting ID when passed on the context object (PR #346 call shape)
+   * @param {string} [meetingContext.microphoneId]  Microphone device ID on the context object (PR #346 call shape)
    * @param {string} [deviceId]  Microphone device ID as the second argument (@webex/components call shape)
    */
-  async action(contextOrMeetingID, deviceId) {
+  async action(meetingContext, deviceId) {
     const {meetingID, deviceId: microphoneId} = resolveDeviceSwitchArgs(
-      contextOrMeetingID,
+      meetingContext,
       deviceId,
       'microphoneId',
     );

--- a/src/MeetingsSDKAdapter/controls/SwitchMicrophoneControl.test.js
+++ b/src/MeetingsSDKAdapter/controls/SwitchMicrophoneControl.test.js
@@ -58,18 +58,37 @@ describe('Switch Microphone Control', () => {
   });
 
   describe('action()', () => {
-    it('calls switchMicrophone() SDK adapter method', async () => {
+    it('calls switchMicrophone() with microphone ID on the context object', async () => {
       meetingsSDKAdapter.switchMicrophone = jest.fn();
       await meetingsSDKAdapter.meetingControls['switch-microphone'].action({meetingID, microphoneId: 'microphoneID'});
-      expect(meetingsSDKAdapter.switchMicrophone).toHaveBeenCalledTimes(1);
-      expect(meetingsSDKAdapter.switchMicrophone).toHaveBeenCalledWith(meetingID, 'microphoneID');
+      expect(meetingsSDKAdapter.switchMicrophone.mock.calls).toEqual([[meetingID, 'microphoneID']]);
     });
 
     it('calls switchMicrophone() with device ID passed as second argument', async () => {
       meetingsSDKAdapter.switchMicrophone = jest.fn();
       await meetingsSDKAdapter.meetingControls['switch-microphone'].action({meetingID}, 'microphoneID');
-      expect(meetingsSDKAdapter.switchMicrophone).toHaveBeenCalledTimes(1);
-      expect(meetingsSDKAdapter.switchMicrophone).toHaveBeenCalledWith(meetingID, 'microphoneID');
+      expect(meetingsSDKAdapter.switchMicrophone.mock.calls).toEqual([[meetingID, 'microphoneID']]);
+    });
+
+    it('calls switchMicrophone() with meeting ID and device ID passed as strings', async () => {
+      meetingsSDKAdapter.switchMicrophone = jest.fn();
+      await meetingsSDKAdapter.meetingControls['switch-microphone'].action(meetingID, 'microphoneID');
+      expect(meetingsSDKAdapter.switchMicrophone.mock.calls).toEqual([[meetingID, 'microphoneID']]);
+    });
+
+    it('prefers context microphone ID when both context and second argument are provided', async () => {
+      meetingsSDKAdapter.switchMicrophone = jest.fn();
+      await meetingsSDKAdapter.meetingControls['switch-microphone'].action(
+        {meetingID, microphoneId: 'context-microphone'},
+        'second-arg-microphone',
+      );
+      expect(meetingsSDKAdapter.switchMicrophone.mock.calls).toEqual([[meetingID, 'context-microphone']]);
+    });
+
+    it('does not call switchMicrophone() when no device ID is provided', async () => {
+      meetingsSDKAdapter.switchMicrophone = jest.fn();
+      await meetingsSDKAdapter.meetingControls['switch-microphone'].action({meetingID});
+      expect(meetingsSDKAdapter.switchMicrophone).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/MeetingsSDKAdapter/controls/SwitchMicrophoneControl.test.js
+++ b/src/MeetingsSDKAdapter/controls/SwitchMicrophoneControl.test.js
@@ -64,5 +64,12 @@ describe('Switch Microphone Control', () => {
       expect(meetingsSDKAdapter.switchMicrophone).toHaveBeenCalledTimes(1);
       expect(meetingsSDKAdapter.switchMicrophone).toHaveBeenCalledWith(meetingID, 'microphoneID');
     });
+
+    it('calls switchMicrophone() with device ID passed as second argument', async () => {
+      meetingsSDKAdapter.switchMicrophone = jest.fn();
+      await meetingsSDKAdapter.meetingControls['switch-microphone'].action({meetingID}, 'microphoneID');
+      expect(meetingsSDKAdapter.switchMicrophone).toHaveBeenCalledTimes(1);
+      expect(meetingsSDKAdapter.switchMicrophone).toHaveBeenCalledWith(meetingID, 'microphoneID');
+    });
   });
 });

--- a/src/MeetingsSDKAdapter/controls/SwitchSpeakerControl.js
+++ b/src/MeetingsSDKAdapter/controls/SwitchSpeakerControl.js
@@ -2,7 +2,7 @@ import {Observable} from 'rxjs';
 import {distinctUntilChanged, map, tap} from 'rxjs/operators';
 import logger from '../../logger';
 import MeetingControl from './MeetingControl';
-import {combineLatestImmediate, isSpeakerSupported} from '../../utils';
+import {combineLatestImmediate, isSpeakerSupported, resolveDeviceSwitchArgs} from '../../utils';
 /**
  * Display options of a meeting control.
  *
@@ -12,16 +12,25 @@ import {combineLatestImmediate, isSpeakerSupported} from '../../utils';
 
 export default class SwitchSpeakerControl extends MeetingControl {
   /**
-   * Calls the the action of the switch speaker control.
+   * Calls the action of the switch speaker control.
    *
-   * @param {object} context  Meeting control context
-   * @param {string} context.meetingID  Meeting ID
-   * @param {string} [context.speakerId]  ID of the speaker device to switch to
-   * @param {string} [deviceId]  ID of the speaker device to switch to (passed by @webex/components)
+   * @param {object|string} contextOrMeetingID  Meeting context object or meeting ID string (@webex/components)
+   * @param {string} context.meetingID  Meeting ID when passed on the context object (PR #346 call shape)
+   * @param {string} [context.speakerId]  Speaker device ID on the context object (PR #346 call shape)
+   * @param {string} [deviceId]  Speaker device ID as the second argument (@webex/components call shape)
    */
-  async action(context, deviceId) {
-    const {meetingID} = context;
-    const speakerId = context.speakerId != null ? context.speakerId : deviceId;
+  async action(contextOrMeetingID, deviceId) {
+    const {meetingID, deviceId: speakerId} = resolveDeviceSwitchArgs(
+      contextOrMeetingID,
+      deviceId,
+      'speakerId',
+    );
+
+    if (speakerId == null) {
+      logger.warn('MEETING', meetingID, 'SwitchSpeakerControl::action()', 'No speaker device ID provided');
+
+      return;
+    }
 
     logger.debug('MEETING', meetingID, 'SwitchSpeakerControl::action()', ['called with', {meetingID, speakerId}]);
 

--- a/src/MeetingsSDKAdapter/controls/SwitchSpeakerControl.js
+++ b/src/MeetingsSDKAdapter/controls/SwitchSpeakerControl.js
@@ -14,11 +14,16 @@ export default class SwitchSpeakerControl extends MeetingControl {
   /**
    * Calls the the action of the switch speaker control.
    *
-   * @param {string} meetingID  Meeting ID
-   * @param {string} speakerID  ID of the speaker device to switch to
+   * @param {object} context  Meeting control context
+   * @param {string} context.meetingID  Meeting ID
+   * @param {string} [context.speakerId]  ID of the speaker device to switch to
+   * @param {string} [deviceId]  ID of the speaker device to switch to (passed by @webex/components)
    */
-  async action({meetingID, speakerId}) {
-    logger.debug('MEETING', meetingID, 'SwitchSpeakerControl::action()', ['called with', {meetingID}]);
+  async action(context, deviceId) {
+    const {meetingID} = context;
+    const speakerId = context.speakerId != null ? context.speakerId : deviceId;
+
+    logger.debug('MEETING', meetingID, 'SwitchSpeakerControl::action()', ['called with', {meetingID, speakerId}]);
 
     await this.adapter.switchSpeaker(meetingID, speakerId);
   }

--- a/src/MeetingsSDKAdapter/controls/SwitchSpeakerControl.js
+++ b/src/MeetingsSDKAdapter/controls/SwitchSpeakerControl.js
@@ -14,14 +14,14 @@ export default class SwitchSpeakerControl extends MeetingControl {
   /**
    * Calls the action of the switch speaker control.
    *
-   * @param {object|string} contextOrMeetingID  Meeting context object or meeting ID string (@webex/components)
-   * @param {string} context.meetingID  Meeting ID when passed on the context object (PR #346 call shape)
-   * @param {string} [context.speakerId]  Speaker device ID on the context object (PR #346 call shape)
+   * @param {object|string} meetingContext  Meeting context object or meeting ID string (@webex/components)
+   * @param {string} [meetingContext.meetingID]  Meeting ID when passed on the context object (PR #346 call shape)
+   * @param {string} [meetingContext.speakerId]  Speaker device ID on the context object (PR #346 call shape)
    * @param {string} [deviceId]  Speaker device ID as the second argument (@webex/components call shape)
    */
-  async action(contextOrMeetingID, deviceId) {
+  async action(meetingContext, deviceId) {
     const {meetingID, deviceId: speakerId} = resolveDeviceSwitchArgs(
-      contextOrMeetingID,
+      meetingContext,
       deviceId,
       'speakerId',
     );

--- a/src/MeetingsSDKAdapter/controls/SwitchSpeakerControl.test.js
+++ b/src/MeetingsSDKAdapter/controls/SwitchSpeakerControl.test.js
@@ -67,5 +67,12 @@ describe('Switch Speaker Control', () => {
       await meetingsSDKAdapter.meetingControls['switch-speaker'].action({meetingID, speakerId: 'speakerID'});
       expect(meetingsSDKAdapter.switchSpeaker).toHaveBeenCalledWith(meetingID, 'speakerID');
     });
+
+    it('calls switchSpeaker() with device ID passed as second argument', async () => {
+      meetingsSDKAdapter.switchSpeaker = jest.fn();
+      await meetingsSDKAdapter.meetingControls['switch-speaker'].action({meetingID}, 'speakerID');
+      expect(meetingsSDKAdapter.switchSpeaker).toHaveBeenCalledTimes(1);
+      expect(meetingsSDKAdapter.switchSpeaker).toHaveBeenCalledWith(meetingID, 'speakerID');
+    });
   });
 });

--- a/src/MeetingsSDKAdapter/controls/SwitchSpeakerControl.test.js
+++ b/src/MeetingsSDKAdapter/controls/SwitchSpeakerControl.test.js
@@ -62,17 +62,37 @@ describe('Switch Speaker Control', () => {
   });
 
   describe('action()', () => {
-    it('calls switchSpeaker() SDK adapter method', async () => {
+    it('calls switchSpeaker() with speaker ID on the context object', async () => {
       meetingsSDKAdapter.switchSpeaker = jest.fn();
       await meetingsSDKAdapter.meetingControls['switch-speaker'].action({meetingID, speakerId: 'speakerID'});
-      expect(meetingsSDKAdapter.switchSpeaker).toHaveBeenCalledWith(meetingID, 'speakerID');
+      expect(meetingsSDKAdapter.switchSpeaker.mock.calls).toEqual([[meetingID, 'speakerID']]);
     });
 
     it('calls switchSpeaker() with device ID passed as second argument', async () => {
       meetingsSDKAdapter.switchSpeaker = jest.fn();
       await meetingsSDKAdapter.meetingControls['switch-speaker'].action({meetingID}, 'speakerID');
-      expect(meetingsSDKAdapter.switchSpeaker).toHaveBeenCalledTimes(1);
-      expect(meetingsSDKAdapter.switchSpeaker).toHaveBeenCalledWith(meetingID, 'speakerID');
+      expect(meetingsSDKAdapter.switchSpeaker.mock.calls).toEqual([[meetingID, 'speakerID']]);
+    });
+
+    it('calls switchSpeaker() with meeting ID and device ID passed as strings', async () => {
+      meetingsSDKAdapter.switchSpeaker = jest.fn();
+      await meetingsSDKAdapter.meetingControls['switch-speaker'].action(meetingID, 'speakerID');
+      expect(meetingsSDKAdapter.switchSpeaker.mock.calls).toEqual([[meetingID, 'speakerID']]);
+    });
+
+    it('prefers context speaker ID when both context and second argument are provided', async () => {
+      meetingsSDKAdapter.switchSpeaker = jest.fn();
+      await meetingsSDKAdapter.meetingControls['switch-speaker'].action(
+        {meetingID, speakerId: 'context-speaker'},
+        'second-arg-speaker',
+      );
+      expect(meetingsSDKAdapter.switchSpeaker.mock.calls).toEqual([[meetingID, 'context-speaker']]);
+    });
+
+    it('does not call switchSpeaker() when no device ID is provided', async () => {
+      meetingsSDKAdapter.switchSpeaker = jest.fn();
+      await meetingsSDKAdapter.meetingControls['switch-speaker'].action({meetingID});
+      expect(meetingsSDKAdapter.switchSpeaker).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/MeetingsSDKAdapter/controls/VideoControl.js
+++ b/src/MeetingsSDKAdapter/controls/VideoControl.js
@@ -18,8 +18,8 @@ export default class VideoControl extends MeetingControl {
    *
    * @param {meetingID}  Meeting ID to mute video
    */
-  action(contextOrMeetingID) {
-    const meetingID = resolveMeetingID(contextOrMeetingID);
+  action(meetingContext) {
+    const meetingID = resolveMeetingID(meetingContext);
 
     logger.debug('MEETING', meetingID, 'VideoControl::action()', ['called with', {meetingID}]);
 

--- a/src/MeetingsSDKAdapter/controls/VideoControl.js
+++ b/src/MeetingsSDKAdapter/controls/VideoControl.js
@@ -3,6 +3,7 @@ import {distinctUntilChanged, map, tap} from 'rxjs/operators';
 import {MeetingControlState} from '@webex/component-adapter-interfaces';
 import logger from '../../logger';
 import MeetingControl from './MeetingControl';
+import {resolveMeetingID} from '../../utils';
 
 /**
  * Display options of a meeting control.
@@ -17,7 +18,9 @@ export default class VideoControl extends MeetingControl {
    *
    * @param {meetingID}  Meeting ID to mute video
    */
-  action({meetingID}) {
+  action(contextOrMeetingID) {
+    const meetingID = resolveMeetingID(contextOrMeetingID);
+
     logger.debug('MEETING', meetingID, 'VideoControl::action()', ['called with', {meetingID}]);
 
     return this.adapter.handleLocalVideo(meetingID);

--- a/src/MeetingsSDKAdapter/controls/VideoControl.test.js
+++ b/src/MeetingsSDKAdapter/controls/VideoControl.test.js
@@ -45,5 +45,11 @@ describe('Video Control', () => {
       expect(meetingsSDKAdapter.handleLocalVideo).toHaveBeenCalledTimes(1);
       expect(meetingsSDKAdapter.handleLocalVideo).toHaveBeenCalledWith(meetingID);
     });
+
+    it('calls handleLocalVideo() with meeting ID passed as a string', async () => {
+      meetingsSDKAdapter.handleLocalVideo = jest.fn();
+      await meetingsSDKAdapter.meetingControls['mute-video'].action(meetingID);
+      expect(meetingsSDKAdapter.handleLocalVideo.mock.calls).toEqual([[meetingID]]);
+    });
   });
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -59,15 +59,13 @@ export function combineLatestImmediate(...observables) {
  * Resolves meetingID from control action arguments.
  * Supports @webex/components string meetingID and PR #346 `{ meetingID }` context object.
  *
- * @param {object|string} contextOrMeetingID
+ * @param {object|string} meetingContext  Meeting ID string or context object with meetingID
  * @returns {string|undefined}
  */
-export function resolveMeetingID(contextOrMeetingID) {
-  if (typeof contextOrMeetingID === 'string') {
-    return contextOrMeetingID;
-  }
-
-  return contextOrMeetingID && contextOrMeetingID.meetingID;
+export function resolveMeetingID(meetingContext) {
+  return typeof meetingContext === 'string'
+    ? meetingContext
+    : meetingContext && meetingContext.meetingID;
 }
 
 /**
@@ -77,22 +75,22 @@ export function resolveMeetingID(contextOrMeetingID) {
  * - `action({ meetingID }, deviceId)`
  * - `action({ meetingID, microphoneId|speakerId|cameraId })` — PR #346
  *
- * @param {object|string} contextOrMeetingID
- * @param {string} [secondArg]  Device ID from the second argument
+ * @param {object|string} meetingContext  Meeting ID string or context object with meetingID
+ * @param {string} [deviceIdArg]  Device ID from the second argument
  * @param {string} contextDeviceKey  Property name on context (`microphoneId`, etc.)
  * @returns {{meetingID: string|undefined, deviceId: string|undefined}}
  */
-export function resolveDeviceSwitchArgs(contextOrMeetingID, secondArg, contextDeviceKey) {
-  if (typeof contextOrMeetingID === 'string') {
-    return {
-      meetingID: contextOrMeetingID,
-      deviceId: secondArg,
-    };
-  }
+export function resolveDeviceSwitchArgs(meetingContext, deviceIdArg, contextDeviceKey) {
+  const meetingID = resolveMeetingID(meetingContext);
+  let deviceId;
 
-  const meetingID = contextOrMeetingID && contextOrMeetingID.meetingID;
-  const fromContext = contextOrMeetingID && contextOrMeetingID[contextDeviceKey];
-  const deviceId = fromContext != null ? fromContext : secondArg;
+  if (typeof meetingContext === 'string') {
+    deviceId = deviceIdArg;
+  } else if (meetingContext && meetingContext[contextDeviceKey] != null) {
+    deviceId = meetingContext[contextDeviceKey];
+  } else {
+    deviceId = deviceIdArg;
+  }
 
   return {meetingID, deviceId};
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -56,6 +56,48 @@ export function combineLatestImmediate(...observables) {
 }
 
 /**
+ * Resolves meetingID from control action arguments.
+ * Supports @webex/components string meetingID and PR #346 `{ meetingID }` context object.
+ *
+ * @param {object|string} contextOrMeetingID
+ * @returns {string|undefined}
+ */
+export function resolveMeetingID(contextOrMeetingID) {
+  if (typeof contextOrMeetingID === 'string') {
+    return contextOrMeetingID;
+  }
+
+  return contextOrMeetingID && contextOrMeetingID.meetingID;
+}
+
+/**
+ * Resolves meetingID and device ID for switch-* controls.
+ * Supports:
+ * - `action(meetingID, deviceId)` — @webex/components
+ * - `action({ meetingID }, deviceId)`
+ * - `action({ meetingID, microphoneId|speakerId|cameraId })` — PR #346
+ *
+ * @param {object|string} contextOrMeetingID
+ * @param {string} [secondArg]  Device ID from the second argument
+ * @param {string} contextDeviceKey  Property name on context (`microphoneId`, etc.)
+ * @returns {{meetingID: string|undefined, deviceId: string|undefined}}
+ */
+export function resolveDeviceSwitchArgs(contextOrMeetingID, secondArg, contextDeviceKey) {
+  if (typeof contextOrMeetingID === 'string') {
+    return {
+      meetingID: contextOrMeetingID,
+      deviceId: secondArg,
+    };
+  }
+
+  const meetingID = contextOrMeetingID && contextOrMeetingID.meetingID;
+  const fromContext = contextOrMeetingID && contextOrMeetingID[contextDeviceKey];
+  const deviceId = fromContext != null ? fromContext : secondArg;
+
+  return {meetingID, deviceId};
+}
+
+/**
  * Helper function for deep merge on objects.
  *
  * @param {object} dest - The destination object.
@@ -112,6 +154,8 @@ export default {
   chainWith,
   combineLatestImmediate,
   deepMerge,
+  resolveDeviceSwitchArgs,
+  resolveMeetingID,
   safeJsonStringify,
 };
 


### PR DESCRIPTION
# COMPLETES #https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-824300

Vidcast demo link for Device Id fix: https://app.vidcast.io/share/f9ab47df-fd36-4380-8879-d6f23054a3b3

Recorded two vidcasts for the meetingid issue on components 1.277.1:

Issue — Narrow screen → ⋯ → Show participants → meetingID undefined (adapter 1.113.0).
https://app.vidcast.io/share/0fcf6564-b341-4ea2-8462-0c25121b6e93

Fix — Same UI with fixed adapter: ⋯ menu and Settings device switch both work.
https://app.vidcast.io/share/512f16af-f8a8-4fdb-8d9b-d3badc858743

## This pull request addresses

Meetings Widget **Settings → Audio/Video device selection** stopped working after `@webex/sdk-component-adapter@1.113.0` shipped with [PR #346](https://github.com/webex/sdk-component-adapter/pull/346). The same regression also broke other meeting controls (join, mute audio/video, settings, exit, roster, share) when invoked from `@webex/components`.

**Customer environment:** `@webex/widgets` ^1.28.2, `@webex/components` 1.277.1, `@webex/sdk-component-adapter` 1.113.0, Chrome on macOS.

**Root cause:** PR #346 refactored meeting control `action()` methods to destructure `{ meetingID }` from a context object. However, `@webex/components@1.277.1` still invokes controls with **string arguments**, not context objects:

| Control type | Actual `@webex/components` call |
|---|---|
| Simple (join, mute, settings, exit, roster, share) | `action(meetingID)` — string |
| Device switches (mic/speaker/camera) | `action(meetingID, deviceId)` — two strings |

When a string is destructured as `{ meetingID }`, `meetingID` becomes `undefined`, producing `Could not find meeting with ID "undefined"`. Device switch controls also missed the selected hardware ID because it is passed as the **second string argument**, not inside a context object.

Two additional issues made switching unreliable even when partially fixed:

1. **Chrome media constraints:** `getUserMedia({ deviceId: id })` (non-exact) silently falls back to the built-in device when a preview stream is already active. `{ exact: deviceId }` is required for reliable switching.
2. **RxJS anti-pattern:** `getStream()` used `new Observable(async (subscriber) => …)`, causing `UnsubscriptionError` when stopping preview streams during rapid device changes.

## by making the following changes

### 1. Shared helpers for `@webex/components` call contract

**File:** `src/utils.js`

- `resolveMeetingID(contextOrMeetingID)` — accepts a string meeting ID or a context object `{ meetingID }`
- `resolveDeviceSwitchArgs(contextOrMeetingID, deviceId)` — resolves meeting ID and device ID from either a context object or the two-string call pattern; context device ID takes precedence when present

### 2. Apply helpers across all meeting controls

**Files:** `AudioControl`, `VideoControl`, `SettingsControl`, `JoinControl`, `ExitControl`, `RosterControl`, `ShareControl`, `SwitchMicrophoneControl`, `SwitchSpeakerControl`, `SwitchCameraControl`

All controls now accept both the PR #346 context-object shape and the string-argument contract used by `@webex/components` today.

Device switch controls additionally:
- Log a warning and return early when no device ID is provided from either source
- Include JSDoc clarifying the two-parameter call pattern (meeting ID + device ID)

### 3. Exact media constraints for Chrome

**File:** `MeetingsSDKAdapter.js` — `switchMicrophone()`, `switchCamera()`

```javascript
deviceId: microphoneID === 'default' ? 'default' : { exact: microphoneID }
```

Also adds missing `await` on `switchSpeaker()`.

### 4. Fix `getStream()` Observable teardown

**File:** `MeetingsSDKAdapter.js` — `getStream()`

- Replaced async Observable subscriber with sync subscriber + async IIFE
- Added `clearTimeout(askingTimeout)` in teardown to prevent errors during device switch

### 5. Unit tests (190 passing)

- `action(meetingID, deviceId)` two-string contract on all three switch controls
- Context device ID precedence when both sources are present
- Early return when both device ID sources are null
- `{ exact: deviceId }` and plain `'default'` constraint behavior in `MeetingsSDKAdapter.test.js`
- `getStream()` DENIED (`NotAllowedError`) and DISABLED (`NotReadableError`) error mapping
- String-argument contract tests on join, audio, video, and settings controls

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- [ ] The testing is done with the amplify link
- [x] **Automated:** `npm run test:unit` — 190/190 tests pass (pre-push hook)
- [x] **Manual (widgets demo):** Linked adapter via `portal:` in `@webex/widgets`, ran `yarn workspace @webex/widgets demo:serve` on https://localhost:9000/
  - Join meeting — meeting ID resolved correctly (no `"undefined"` errors)
  - Settings → switch microphone — selected device applied
  - Settings → switch speaker — selected device applied
  - Settings → switch camera — selected device applied
  - Mute/unmute audio and video — working
  - Preview stream teardown during rapid device changes — no `UnsubscriptionError`

## The GAI Coding Policy And Copyright Annotation Best Practices ##

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### Checklist before merging

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the testing document

---