### PR TITLE
fix(release): retry npm publish after publish permission fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@
 
 Release notes for each version are tracked in [CHANGELOG.md](./CHANGELOG.md).
 
+## Architecture
+
+This package is a **JavaScript data layer** — it does not ship React UI. Adapters wrap the [Webex JavaScript SDK](https://github.com/webex/webex-js-sdk), implement [`@webex/component-adapter-interfaces`](https://www.npmjs.com/package/@webex/component-adapter-interfaces), and expose meeting, people, and rooms data as **RxJS observables** for [`@webex/components`](https://github.com/webex/components) to consume.
+
+```
+Webex JS SDK  →  @webex/sdk-component-adapter (this repo)  →  @webex/components (React UI)
+```
+
+Peer dependencies: `webex` and `rxjs`.
+
 ## Project Status
 
 The Webex Component System is considered to be in beta stage and it's not a generally available product from Webex at this time.
@@ -30,6 +40,7 @@ We would love for you to use the Webex Component System and be part of the feedb
 
 ## Table of Contents
 
+- [Architecture](#architecture)
 - [Install](#install)
 - [Usage](#usage)
   - [Setup](#setup)


### PR DESCRIPTION
# COMPLETES #351

## This pull request addresses

Follow-up to PR #352. After the npm token was fixed, semantic-release authenticated as **`webex-jenkins`** but **`npm publish` failed with E404** — the account lacked publish access to the `@webex` org/package. Git tag **`v1.113.2`** and the `chore(release): 1.113.2` commit were created on `master`, but npm remained at **1.113.0**.

@mkesavan13  has since fixed npm publish permissions. This dummy PR adds a new releasable commit on `master` (after `v1.113.2`) so semantic-release can publish to the registry.

**Prior release attempts:**
- #350 merge → `v1.113.1` tag; npm publish failed (`EINVALIDNPMTOKEN`)
- #352 merge → `v1.113.2` tag; npm publish failed (`E404` / publish permission)

Related: https://github.com/webex/sdk-component-adapter/issues/351

## by making the following changes

- Adds an **Architecture** section to `README.md` describing the adapter as a JavaScript/RxJS data layer (not React UI), its relationship to `@webex/component-adapter-interfaces` and `@webex/components`, and peer dependencies (`webex`, `rxjs`)
- Updates the table of contents with an Architecture link
- **No functional or API changes** — documentation only
- Merge commit uses `fix(release):` so semantic-release publishes a new patch version to npm (expected **1.113.3**), which includes PR #350 meeting-controls fix already on `master`

### Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- [ ] The testing is done with the amplify link
- README markdown change only; no runtime behavior to test
- Unit/integration tests expected to run in CI on merge
- Post-merge verification:
  - CircleCI `release` job passes
  - `npm view @webex/sdk-component-adapter version` shows the new version (expected **1.113.3**)

## The GAI Coding Policy And Copyright Annotation Best Practices ##

- [x] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### Checklist before merging

- [x] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the testing document

---